### PR TITLE
close question after all players failed answering

### DIFF
--- a/beopardy
+++ b/beopardy
@@ -1,0 +1,247 @@
+#!/usr/bin/perl -w
+
+# vim:set ts=4 sw=4 cin sm:
+
+# This code is under the BSD Licence
+# (c) by Stefan `Sec` Zehl <sec@42.org>
+# $Id$
+
+# based on snippets of romanclock by Abigail
+
+use strict;
+use Tk;
+use Tk::Font;
+use Tk::X11Font;
+
+my $debug=1;
+my $override=0;					# Ignore windowmanager?
+my $force=1;					# move focus for kbd-mode?
+
+my ($width,$height)=(640,480);	# Size of game field.
+my $catwidth =10;				# Width of categories.
+my $namewidth=10;				# Width of player names
+
+print "Reading questions....\n";
+my %jdata;
+open (J,"<Test.jd") || die;
+my ($nam,$c);
+while (<J>){
+	chomp;
+	next if ((!defined $nam) && (!/^>/));
+	next if /^\s*(#|$)/;
+	if (/^>(.*)/){
+		if(defined $nam){
+			printf "%-20s:%2d\n",$nam,$c if ($debug);
+		};
+		$nam=$1;
+		$c=0;
+		next;
+	}
+	$jdata{$nam}[++$c]=$_;
+};
+close(J);
+printf "%-20s:%2d\n",$nam,$c if ($debug);
+print "Totalling ",(scalar keys %jdata)," categories.\n";
+
+my @players=qw(Foo Bar Baz);
+my @points=(0,0,0);
+
+unshift @players,"Nobody";
+unshift @points,0;
+
+my @Cat;
+my $gamefile=shift||"Test.jg";
+$gamefile =~ /^([^.]+)(.jg)?/;
+my $title=$1;		# Titel des Spielfelds.
+my $q=5;			# Wieviele Fragen/Kategorie?
+
+print "\nReading game '$title' ...\n";
+open(G,"<$gamefile") || die;
+while (<G>){
+	chomp;
+	next if (/^\s*(#|$)/);
+	push @Cat,$_;
+};
+close(G);
+
+for (@Cat){
+	printf "%-20s:%2d\n",$_,$#{$jdata{$_}};
+	if ($#{$jdata{$_}} < $q){
+		print "ERROR: not enough questions in \"$_\"\n";
+	};
+	if ($#{$jdata{$_}} > $q){
+		print "WARN : too many questions in \"$_\"\n";
+	};
+};
+print "\n";
+
+
+# Here starts the Tk part...
+my $tl = MainWindow -> new -> toplevel;
+
+my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--25-*-*-*-*-*-iso8859-1');
+print "Question-Font:\n$qfont\n";
+
+my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--20-*-*-*-*-*-iso8859-1');
+print "Title-Font:\n$tfont\n";
+
+$tl->configure(-height => $height, -width => $width);
+$tl->resizable(0,0);
+$tl->packPropagate(0);	# Keep the size.
+$tl->overrideredirect(1) if ($override);
+
+# Title of Gamefield
+my $tlabel = $tl -> Label (
+		-text	=> $title,
+		-relief => 'ridge',
+		-font	=> $tfont,
+) -> pack(-fill	=> 'x');
+
+$tl->eventAdd('<<quit>>'=>'<Button-3>');
+$tl->eventAdd('<<quit>>'=>'<q>');
+$tl->bind('<<quit>>',sub{print "Done:\n",map {sprintf "%10s:%5d\n",$players[$_],$points[$_]} sort {$points[$b]<=>$points[$a]} (1..$#points);exit});
+
+sub selectQuest;
+sub answerQuest;
+sub moveCrsr;
+
+# Game-Buttons.
+my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
+my @button;	# The TkButtons 
+my @pts;	# Who got the points from this question?
+my @frame;  # The TkFrames, one per category.
+for my $cat (0..$#Cat){
+	$frame[$cat]=$bframe->Frame->pack(
+			-side	=>'left',
+			-fill	=>'both',
+			-expand	=> 1,
+	);
+
+	$button[$cat][0] = $frame[$cat]->Label(
+			-width => $catwidth,
+			-text => $Cat[$cat],
+	)->pack(-fill => 'both');
+
+	for my $q (1..$q) {
+		$button[$cat][$q] = $frame[$cat]->Button(
+				-text		=> "${q}00",
+				-command	=> [\&selectQuest,$cat,$q],
+		)->pack( -fill => 'both', -expand => 1);
+		$button[$cat][$q]->bind('<h>',[\&moveCrsr,$cat-1,$q  ]);
+		$button[$cat][$q]->bind('<j>',[\&moveCrsr,$cat  ,$q+1]);
+		$button[$cat][$q]->bind('<k>',[\&moveCrsr,$cat  ,$q-1]);
+		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
+	};
+};
+$button[0][1]->focusForce if ($force);
+
+# Scoreboard.
+my $sframe=$tl->Frame->pack(-side=>'top',-fill=>'x');
+my @pborder;
+my @pframes;
+my @pnames;
+my @pscores;
+for (1..$#players){
+	if ($_ == $#players){
+		$pborder[$_]=$sframe;
+	}else{
+		$pborder[$_]=$sframe->Frame->pack(
+				-side	=>'left',
+				-fill	=>'x',
+				-expand	=>1,
+		);
+	};
+
+	$pframes[$_]=$pborder[$_]->Label( -relief=>'ridge')->pack( -side=>'left');
+	$pnames[$_] =$pframes[$_]->Label(
+			-width		=>$namewidth,
+			-anchor		=>'w',
+			-textvar	=> \$players[$_],
+	)->pack;
+	$pscores[$_]=$pframes[$_]->Label(
+			-textvar	=> \$points[$_],
+			-anchor		=>'e',
+	)->pack(-fill=>'x');
+};
+
+print "\nGame start.\n\n";
+MainLoop;
+
+# We selected a question...
+
+sub selectQuest{
+	my ($c,$f)=@_;
+#	print "selected ",join(",",@_),"\n" if ($debug);
+	print "Q$f / \"$Cat[$c]\": $jdata{$Cat[$c]}[$f]\n";
+
+	my $tl = MainWindow->new->toplevel;
+
+	$tl->configure(-height => $height, -width => $width);
+	$tl->resizable(0,0);
+	$tl->packPropagate(0);	# Keep the size.
+	$tl->overrideredirect(1) if($override);
+
+		my $tlabel = $tl->Label(
+				-text	=> $Cat[$c],
+				-relief	=> 'ridge',
+				-font	=> $tfont,
+		) -> pack(-fill	=> 'x');
+
+		my $text;
+		($text=$jdata{$Cat[$c]}[$f])=~ s/\\n/\n/g;
+		my $question = $tl->Label(
+				-text	=> $text,
+				-font	=> $qfont,
+		)->pack(
+				-fill	=>'both',
+				-expand	=>1
+		);
+
+		$tl->focusForce if ($force);
+
+		$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
+};
+
+# User answered the Question.
+sub answerQuest{
+	my ($crap,$c,$f,$key)=@_;
+#	print "answered: $c $f $key\n";
+	if($key eq "q"){
+		$crap->destroy;
+		$button[$c][$f]->focusForce if ($force);
+		return;
+	};
+	$key="0" if($key eq "`"); # Be nice on ami-kbd
+	if($key=~/^\d$/){
+		if (($key <= $#players)&&($key>=0)){
+				print "good for ",$players[$key],"\n";
+				$points[$key]+=$f*100;
+				if(defined $pts[$c][$f]){
+					$points[$pts[$c][$f]]-=$f*100;
+					print "EDIT: $players[$pts[$c][$f]] lost answer\n";
+				};
+				$crap->destroy;
+				$button[$c][$f]->configure(
+						-text				=> $players[$key],
+						-relief				=> "flat",
+						-foreground			=>'grey',
+						-activeforeground	=>'grey',
+				);
+				$pts[$c][$f]=$key;
+				$button[$c][$f]->focusForce if ($force);
+				return;
+		};
+	};
+	print "I don't like this key ($key)...\n" if($debug);
+};
+
+sub moveCrsr{
+	my ($widget,$c,$f)=@_;
+	$c=0 if($c>$#Cat);
+	$c=$#Cat if($c<0);
+	$f=1 if($f>$q);
+	$f=$q if($f<1);
+	$button[$c][$f]->focus;
+	return;
+};
+

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.13 2004/12/25 13:11:47 sec Exp sec $;
+	q$Id: beopardy,v 1.14 2004/12/25 16:03:29 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -296,6 +296,7 @@ my $tlabel = $tl -> Label (
 $tl->eventAdd('<<quit>>'=>'<Button-3>');
 $tl->eventAdd('<<quit>>'=>'<Q>');
 $tl->bind('<<quit>>',sub{&snd_stop();print "Done:\n",map {sprintf "%10s:%5d\n",$players[$_],$points[$_]} sort {$points[$b]<=>$points[$a]} (1..$#points);exit});
+#$tl->bind('<Button-2>',sub{$tl->focus;$tl->focusForce;$buttons[1][1]->focus};);
 $tl->bind('<Z>',sub{&snd_zap()});
 
 # Game-Buttons.
@@ -330,13 +331,19 @@ for my $cat (0..$#Cat){
 				-text		=> "${q}00",
 				-command	=> [\&selectQuest,$tl,$cat,$q],
 				-font		=> $tfont,
+				-highlightcolor => "red",
 		)->pack( -fill => 'both', -expand => 1);
 		$button[$cat][$q]->bind('<h>',[\&moveCrsr,$cat-1,$q  ]);
 		$button[$cat][$q]->bind('<j>',[\&moveCrsr,$cat  ,$q+1]);
 		$button[$cat][$q]->bind('<k>',[\&moveCrsr,$cat  ,$q-1]);
 		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
-		$button[$cat][$q]->bind('<e>',[\&edit_pts,$cat  ,$q  ]);
-		$button[$cat][$q]->bind('<f>',[\&finish]);
+		$button[$cat][$q]->bind('<E>',[\&edit_pts,$cat  ,$q  ]);
+		$button[$cat][$q]->bind('<F>',[\&finish]);
+		$button[$cat][$q]->bind('<r>',[\&randomply]);
+#		$button[$cat][$q]->bind('<FocusIn>',sub{
+#				$button[$cat][$q]->configure(-border=>10)});
+#		$button[$cat][$q]->bind('<FocusOut>',sub{
+#				$button[$cat][$q]->configure(-border=>2)});
 # Fuer mh, der die VI-Keys nicht mag...
 		$button[$cat][$q]->bind('<Left>' ,[\&moveCrsr,$cat-1,$q  ]);
 		$button[$cat][$q]->bind('<Down>' ,[\&moveCrsr,$cat  ,$q+1]);
@@ -1235,4 +1242,33 @@ sub finish{
 	$dlg->grab;
 	$dlg->focusForce;
 	$tl->lower($dlg);
+};
+
+sub randomply{
+	my ($wid)=@_;
+	my $dlg=$wid->Toplevel;
+	$dlg->overrideredirect(1);
+
+	my $ply=int(rand($#players-1))+1;
+	$global_dbl_ply=$ply;
+
+	my $q=$dlg->Button(
+			-relief		=> "raised",
+			-border		=> 5,
+			-background	=> $colors[$ply],
+			-foreground	=> "white",
+			-font       => $qfont,
+			-text		=> $players[$ply],
+			-command	=> sub {$wid->focusForce if ($force);$dlg->destroy},
+			)->pack();
+
+# Repositioning looks stupid.
+#	$dlg->idletasks;
+#	$dlg->geometry(sprintf "+%d+%d",($dlg->screenwidth-$dlg->width)/2,($dlg->screenheight-$dlg->height)/2);
+	$dlg->geometry(sprintf "+%d+%d",($dlg->screenwidth-100)/2,($dlg->screenheight-40)/2);
+
+	$dlg->raise;
+	$dlg->grab if ($force);
+	$dlg->focusForce if($force);
+	$q->focus;
 };

--- a/beopardy
+++ b/beopardy
@@ -25,6 +25,7 @@ my $force=0;					# move focus for kbd-mode?
 my $tty=0;						# use tty/serial input?
 my $splash=0;					# Display a splashscreen?
 my $soundd=0;					# Use Soundd-output?
+my $mood=0;						# Publish mood?
 my $socket=0;					# tty emulated by tcp socket?
 my $geometry=0;					# How big should I be?
 my $readfile;					# Should I read from a file?
@@ -51,7 +52,7 @@ my %ln = (
 sub _ {
 	my $key=shift;
 
-#	return $key; # Deutsch-Mode.
+	return $key; # Deutsch-Mode.
 
 	if (defined ($ln{$key})){
 		return $ln{$key};
@@ -61,7 +62,7 @@ sub _ {
 };
 
 my %opt;
-getopts('ydoftsg:r:hwb', \%opt);
+getopts('ydoftsg:r:hwbm', \%opt);
 
 # Possible screen sizes
 my %screen=( 320 => 200,
@@ -87,6 +88,7 @@ beopardy -options Gamefile Player1 Player2 ...
 -r <file>	Read saved game from File.
 -w		Save game progress for reading with -r.
 -y		Contact soundd at localhost 32001
+-m		Moodlamp support. Works via soundd (requires -y)
 -g <size>	geometry. Select window size.
 		0: fullscreen (default)
 EOF
@@ -106,6 +108,11 @@ $socket=1	if (defined $opt{s});
 $savefile=1	if (defined $opt{w});
 $splash=1	if (defined $opt{b});
 $soundd=1	if (defined $opt{y});
+$mood=1		if (defined $opt{m});
+
+if($mood && !$soundd){
+	die "Mood support requires soundd!";
+};
 
 if($opt{r}){ # Read savefile
 	if ( -f $opt{r} ){
@@ -118,6 +125,7 @@ if ($tty){$splash=1};	# tty requires splash.
 
 my $tl = MainWindow -> new -> toplevel;
 $tl->appname(beopardy);
+$tl->bind('<M>',sub{ snd_play("start"); });
 my ($width,$height)=($tl->screenwidth,$tl->screenheight);	# Size of game field.
 
 if (defined $opt{g}){
@@ -180,6 +188,7 @@ if($soundd){
 		autoflush Soundd;
 };
 &snd_stop(0); # Just to make sure, and to install snd_eat.
+&mood("boot");
 
 print "Reading questions....\n";
 my %jdata;
@@ -513,7 +522,7 @@ if($splash){ # Splash-Screen
 			-font	=> $qfont,
 #			-width	=> 30,
 			-height	=> 2,
-			-command	=> sub {$splash=0;&snd_stop;&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$dlg->destroy;
+			-command	=> sub {$splash=0;&snd_stop;&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);&mood("start");$dlg->destroy;
 			print SAV "[ply] ",join("/",@players),"\n";
 			},
 	)->pack(
@@ -550,10 +559,12 @@ sub ser_PlyEn {
 	}else{
 		die "ser_en: $_[0]\n";
 	};
+	&mood("setup 0");
 };
 
 sub ply_focus {
 	my ($crap, $key)=@_;
+	&mood("setup $key");
 	if ($key>$#players){
 		if($tty && ($key==($#players+1))){
 			my $f=$splash_frame;
@@ -723,9 +734,11 @@ sub selectQuest{
 	$tl->focusForce if ($force);
 
 	$tl->bind('<S>',sub{&snd_stop()});
+	$tl->bind('<R>',sub{&snd_resume()});
 	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
 
 	$tl->waitVisibility; # To fix stacking order
+	&mood("question");
 	if($global_is_dbl){
 		$tl->afterIdle(sub {&ser_answerQuest($tl,$c,$f) if ($tty);});
 	}else{
@@ -744,6 +757,7 @@ sub ser_answerQuest {
 	}else{
 		$key=<Client>;
 	};
+	&mood("player $key");
 	print "SER<: <$key>\n" if($debug);
 
 	&snd_stop if($snd_save);
@@ -789,6 +803,7 @@ sub ser_answerQuest {
 			-command	=> sub{$ich->destroy;
 							  &ser_reset;
 #							  &snd_stop;
+							  &mood("question");
 							  &snd_resume;
 							  $crap->focusForce if ($force);
 							  &ser_en($crap,$c,$f)},
@@ -824,6 +839,12 @@ sub ser_dis{
 	$tl->fileevent(\*Client,'readable',[\&ser_noinp]);
 };
 
+sub mood{
+	return if (!$soundd);
+	my($sound)=(shift);
+	print Soundd "M $sound\r\n";
+	Soundd->flush();
+};
 sub snd_play{
 	return if (!$soundd);
 	my($sound,$what)=(shift,shift);
@@ -864,6 +885,7 @@ sub answerQuest{
 	my $sgn=1;
 	if(lc($key) =~ "q"){
 		&snd_stop(0);
+		&mood("board");
 		$crap->destroy;
 		&ser_dis if ($tty);  # "input nach 'q' auf frage" fix.
 		$button[$c][$f]->focusForce if ($force);
@@ -883,6 +905,9 @@ sub answerQuest{
 		if ($key<0) {
 			$sgn=-$sgn;
 			$key=-$key;
+			&mood("wrong");
+		}else{
+			&mood("right");
 		};
 		if ($key <= $#players){
 			&updPlayfield($c,$f,$key,$sgn);
@@ -1075,6 +1100,7 @@ sub enterdbl {
 	$br->bind('<Left>',sub{&dblplychg($ply,-1)});
 	$br->bind('<Up>',sub{&amt_chg(+50)});
 	$br->bind('<Down>',sub{&amt_chg(-50)});
+	&mood("double $global_dbl_ply");
 
 	$br->focus;
 	$br->focusForce if($force);
@@ -1093,6 +1119,7 @@ sub dblplychg{
 	$global_dbl_ply=1 if ($global_dbl_ply>$#players);
 	$ply->configure(-text => $players[$global_dbl_ply],
 			-background	=> $colors[$global_dbl_ply]);
+	&mood("double $global_dbl_ply");
 };
 
 sub edit_pts {
@@ -1249,6 +1276,7 @@ sub finish{
 	my $rframe;
 	my @win=sort {$points[$b]<=>$points[$a]} (1..$#points);
 	unshift @win,"0";
+	&mood("end");
 
 #	$dlg->configure(-height => $height, -width => $width);
 #	$dlg->resizable(0,0);

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.15 2004/12/25 16:46:33 sec Exp sec $;
+	q$Id: beopardy,v 1.16 2006/12/23 16:09:21 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -16,6 +16,7 @@ use Socket;
 use FileHandle;
 use Getopt::Std;
 use IO::Handle;
+use Encode;
 
 # Global options. Set via getopt.
 my $debug=0;
@@ -155,7 +156,7 @@ if ($tty){
 		print "connection from $name [", inet_ntoa($iaddr), "] at port $iport\n";
 	}else{
 		# Be sure to set device to -crtscts 19200
-		open(Client,"+>/dev/cuaa0") || die "open: $!";
+		open(Client,"+>/dev/cuaU0") || die "open: $!";
 	};
 	print "done.\n";
 	autoflush Client;
@@ -273,9 +274,9 @@ my @points;
 
 # Here starts the Tk part...
 #my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
-my $qfont=$tl->X11Font('-monotype-arial-medium-r-*-*-50-*-*-*-*-*-ascii-*');
+#my $qfont=$tl->X11Font('-monotype-arial-medium-r-*-*-50-*-*-*-*-*-iso8859-*');
+my $qfont=$tl->X11Font('-monotype-arial-medium-r-*-*-50-*-*-*-*-*-iso8859-1');
 print "Question-Font:\n$qfont\n" if ($debug);
-#my $qsfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
 
 #my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
 #my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-45-*-*-*-*-*-iso8859-1');
@@ -284,6 +285,12 @@ print "Title-Font:\n$tfont\n" if($debug);
 
 my $sfont=$tl->X11Font('-monotype-courier new-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
 print "Small-Font:\n$sfont\n" if($debug);
+
+my $fixedfont=$tl->X11Font('-monotype-courier new-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
+print "Fixed-Font:\n$fixedfont\n" if($debug);
+
+my $utf8font=$tl->X11Font('-jis-*-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
+print "UTF8-Font:\n$utf8font\n" if($debug);
 
 unless ($qfont and $tfont and  $sfont ){
 	die "One or more fonts failed.\n";
@@ -541,13 +548,16 @@ sub ply_focus {
 			my $row=$key-1;
 			$players[$key]="New Player $key";
 			$points[$key]=0;
-			my $e = $f->Entry(qw/-relief sunken -width 40/);
+			my $e = $f->Entry(-relief	=> "sunken",
+						-font	=> $sfont,
+			   			-width	=> 30);
 			$e->insert(0,$players[$key]);
 			$e->bind('<Return>',[\&ser_reset,\&ser_PlyEn]);
 			$e->bind('<FocusOut>',[\&set_ply,$key]);
 
 			my $l = $f->Label(-text => "Player $key", 
 					-width		=> $namewidth,
+					-font		=> $sfont,
 					-background	=> $colors[$key],
 					-foreground	=> "white",
 					-anchor 	=> 'e', -justify => 'right');
@@ -664,6 +674,13 @@ sub selectQuest{
 		);
 	}else{
 		my $txt=$jdata{$Cat[$c]}[$f];
+		my $magicfont=$qfont;
+	if ($txt =~ s/^\[fixed\]//){
+		$magicfont=$fixedfont;
+	};
+	if ($txt =~ s/^\[utf8\]//){
+		$txt=Encode::decode_utf8($txt);
+	};
 		if(defined($fnam)&&($typ eq "snd")){
 			if(!$soundd){$txt.="\n[ERR:Nosound]"};
 			&snd_play($fnam);
@@ -681,7 +698,7 @@ sub selectQuest{
 		};
 		$question = $tl->Label(
 			-text	=> $txt,
-			-font	=> $qfont,
+			-font	=> $magicfont,
 			-justify	=> "left",
 		);
 	};

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.14 2004/12/25 16:03:29 sec Exp sec $;
+	q$Id: beopardy,v 1.15 2004/12/25 16:46:33 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -273,12 +273,12 @@ my @points;
 
 # Here starts the Tk part...
 #my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
-my $qfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-40-*-*-*-*-*-ascii-*');
+my $qfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-50-*-*-*-*-*-ascii-*');
 print "Question-Font:\n$qfont\n" if ($debug);
 #my $qsfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
 
 #my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
-my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-25-*-*-*-*-*-iso8859-1');
+my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-45-*-*-*-*-*-iso8859-1');
 print "Title-Font:\n$tfont\n" if($debug);
 
 $tl->configure(-height => $height, -width => $width);
@@ -440,7 +440,9 @@ if($splash){ # Splash-Screen
 	$dlg->overrideredirect(1);
 	my $q=$dlg->Label(qw/-relief raised -width 80/)->pack;
 
+	$dlg->bind('<M>',sub{
 	snd_play("start");
+			});
 	$i= $q->Pixmap("beopardy",-file => "img/beopardy.xpm");
 
 	if(defined($i)){
@@ -651,9 +653,14 @@ sub selectQuest{
 			&snd_play($fnam);
 			$snd_save=$fnam;
 		};
-		if($txt=~s/^\[(\w+):.*?\]\s*//){
+		if($txt=~s/^\[snd:.*?\]\s*//){
 			if(!$txt){
 				$txt=_("Zuhören...");
+			};
+		};
+		if($txt=~s/^\[img:.*?\]\s*//){
+			if(!$txt){
+				$txt=_("[ERR:Noimg]");
 			};
 		};
 		$question = $tl->Label(
@@ -670,6 +677,7 @@ sub selectQuest{
 
 	$tl->focusForce if ($force);
 
+	$tl->bind('<S>',sub{&snd_stop()});
 	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
 
 	$tl->waitVisibility; # To fix stacking order

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.3 2000/12/25 17:57:09 sec Exp sec $;
+	q$Id: beopardy,v 1.4 2000/12/28 16:17:46 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -185,7 +185,7 @@ if ($#ARGV>0){
 	@players=qw(Foo Bar Baz);
 };
 
-my @colors=qw(darkred darkgreen darkblue);
+my @colors=qw(grey darkred darkgreen darkblue);
 
 unshift @players,"Nobody";
 my @points=(0)x($#players+1);
@@ -267,6 +267,8 @@ for (1..$#players){
 			-width		=>$namewidth,
 			-anchor		=>'w',
 			-textvar	=> \$players[$_],
+			-background	=> $colors[$_],
+			-foreground	=> "white",
 	)->pack;
 	$pscores[$_]=$pframes[$_]->Label(
 			-textvar	=> \$points[$_],
@@ -411,6 +413,7 @@ sub answerQuest{
 	my $sgn=1;
 	if($key eq "q"){
 		$crap->destroy;
+#&ser_dis;
 		$button[$c][$f]->focusForce if ($force);
 		return;
 	};
@@ -446,11 +449,9 @@ sub updPlayfield {
 	push @{$pts[$c][$f]},$sgn*$key;
 	my $pl=join("\n",map {($_<0?"-":" ").$players[abs]} @{$pts[$c][$f]});
 #	my $pl=join("",map {($_<0?"-":"+").abs} @{$pts[$c][$f]});
-	my $col;
-	$col=${pts[$c][$f]}[-1];
+	my $col=${pts[$c][$f]}[-1];
 	if($col<0){$col=0};
 	$col=$colors[$col];
-	print "$col<------------\n";
 	print ">$pl<\n";
 #	my $oheight=$button[$c][$f]->height;
 	$button[$c][$f]->configure(
@@ -463,6 +464,7 @@ sub updPlayfield {
 			-background			=> $col,
 	);
 #	$button[$c][$f]->GeometryRequest(40,$oheight/2);
+    print "Pts:\n",map {sprintf "%s:%d/",$players[$_],$points[$_]} (1..$#points);
 	return $pl;
 }
 

--- a/beopardy
+++ b/beopardy
@@ -50,7 +50,7 @@ my %ln = (
 sub _ {
 	my $key=shift;
 
-	return $key; # Deutsch-Mode.
+#	return $key; # Deutsch-Mode.
 
 	if (defined ($ln{$key})){
 		return $ln{$key};
@@ -273,7 +273,7 @@ my @points;
 
 # Here starts the Tk part...
 #my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
-my $qfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-50-*-*-*-*-*-ascii-*');
+my $qfont=$tl->X11Font('-monotype-arial-medium-r-*-*-50-*-*-*-*-*-ascii-*');
 print "Question-Font:\n$qfont\n" if ($debug);
 #my $qsfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
 
@@ -1257,7 +1257,7 @@ sub randomply{
 	my $dlg=$wid->Toplevel;
 	$dlg->overrideredirect(1);
 
-	my $ply=int(rand($#players-1))+1;
+	my $ply=int(rand($#players))+1;
 	$global_dbl_ply=$ply;
 
 	my $q=$dlg->Button(

--- a/beopardy
+++ b/beopardy
@@ -278,8 +278,16 @@ print "Question-Font:\n$qfont\n" if ($debug);
 #my $qsfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
 
 #my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
-my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-45-*-*-*-*-*-iso8859-1');
+#my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-45-*-*-*-*-*-iso8859-1');
+my $tfont=$tl->X11Font('-monotype-times new roman-medium-r-*-*-60-*-*-*-*-*-iso8859-1');
 print "Title-Font:\n$tfont\n" if($debug);
+
+my $sfont=$tl->X11Font('-monotype-courier new-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
+print "Small-Font:\n$sfont\n" if($debug);
+
+unless ($qfont and $tfont and  $sfont ){
+	die "One or more fonts failed.\n";
+};
 
 $tl->configure(-height => $height, -width => $width);
 $tl->resizable(0,0);
@@ -320,6 +328,7 @@ for my $cat (0..$#Cat){
 	$button[$cat][0] = $frame[$cat]->Label(
 			-width	=> $catwidth,
 			-text	=> $Cat[$cat],
+			-font	=> $sfont,
 	)->pack(-fill	=> 'both');
 
 	for my $q (1..$q) {
@@ -339,7 +348,8 @@ for my $cat (0..$#Cat){
 		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
 		$button[$cat][$q]->bind('<E>',[\&edit_pts,$cat  ,$q  ]);
 		$button[$cat][$q]->bind('<F>',[\&finish]);
-		$button[$cat][$q]->bind('<r>',[\&randomply]);
+		$button[$cat][$q]->bind('<R>',[\&randomply]);
+		$button[$cat][$q]->bind('<r>',[\&random_ray]);
 #		$button[$cat][$q]->bind('<FocusIn>',sub{
 #				$button[$cat][$q]->configure(-border=>10)});
 #		$button[$cat][$q]->bind('<FocusOut>',sub{
@@ -379,6 +389,7 @@ for (1..$#players){
 	$pframes[$_]=$pborder[$_]->Label( -relief=>'ridge')->pack( -side=>'left');
 	$pnames[$_] =$pframes[$_]->Label(
 			-width		=>$namewidth,
+			-font		=> $sfont,
 			-anchor		=>'w',
 			-textvar	=> \$players[$_],
 			-background	=> $colors[$_],
@@ -386,6 +397,7 @@ for (1..$#players){
 	)->pack;
 	$pscores[$_]=$pframes[$_]->Label(
 			-textvar	=> \$points[$_],
+			-font		=> $sfont,
 			-anchor		=>'e',
 	)->pack(-fill=>'x');
 };
@@ -455,7 +467,10 @@ if($splash){ # Splash-Screen
 	$splash_frame=$f;
 	my $row=0;
 	foreach (1..$#players) {
-		my $e = $f->Entry(qw/-relief sunken -width 40/);
+#		my $e = $f->Entry(qw/-relief sunken -width 40/);
+		my $e = $f->Entry(-relief	=> "sunken",
+						-font	=> $sfont,
+			   			-width	=> 30);
 		$e->insert(0,$players[$_]);
 		if($tty){
 			$e->bind('<Return>',[\&ser_reset,\&ser_PlyEn]);
@@ -468,6 +483,7 @@ if($splash){ # Splash-Screen
 			-width		=> $namewidth,
 			-background	=> $colors[$_],
 			-foreground	=> "white",
+			-font		=> $sfont,
 			-anchor 	=> 'e', -justify => 'right');
 		Tk::grid( $l, -row => $row, -column => 0, -sticky => 'e');
 		Tk::grid( $e, -row => $row++, -column => 1,-sticky => 'ew');
@@ -1076,6 +1092,7 @@ sub edit_pts {
 #		print "$sgn $ply $dbl\n";
 		$ebtn[$_]=$ich->Button(
 				-text		=> "$players[$ply] $sgn [$dbl]",
+				-font		=> $sfont,
 				-command	=> sub{ ; },
 				-background	=> $colors[$ply],
 				-foreground	=> "white",
@@ -1084,6 +1101,7 @@ sub edit_pts {
 
 	my $br=$ich->Button(
 			-text		=> 'Use: 0-4 +-d and Left-Right.',
+			-font		=> $sfont,
 			-command	=> sub{
 							$ichtl->destroy;
 							updBox($widget,$c,$f);
@@ -1172,25 +1190,27 @@ sub updBox{
 		pop@{$log[$c][$f]};
 	};
 
+	my $nothing=1;
 	for(@{$log[$c][$f]}){
 		my ($sgn,$ply,$dbl)=@{$_};
 		next if($sgn==0);
 		$pl.="\n"if($pl);
 		$pl.=($sgn==1?"+":"-").$players[$ply].($dbl?"[d]":"");
+		$nothing=0 if($sgn!=0);
 		if($sgn>0 && $ply>0){
 			$col=$colors[$ply];
 		}
 	}
 
 	$wid->configure(
-			-text				=> $pl,
-			-relief				=> "flat",
+			-text				=> $nothing?"<undef>":$pl,
+			-relief				=> $nothing?"raised":"flat",
 			-foreground			=>'grey',
 			-activeforeground	=>'grey',
 			-height				=> 0,
 			-width				=> 0,
-			-background			=> $col,
-			-font				=> "fixed",
+			-background			=> $nothing?"#d0d0d0":$col,
+			-font				=> $sfont,
 	);
 }
 
@@ -1218,7 +1238,7 @@ sub finish{
 	foreach (1..$#players) {
 		my $e = $f->Label(qw/-relief sunken/);
 		$e->configure(-text => $points[$win[$_]]);
-		$e->configure(-font => $qfont) if ($_ == 1);
+		$e->configure(-font => ($_==1)?$qfont:$sfont);
 
 		my $l = $f->Label(-text => "$players[$win[$_]]", 
 			-width		=> $namewidth,
@@ -1234,7 +1254,7 @@ sub finish{
 	}
 	$dlgbtn=$q->Button(
 			-text	=> "bye",
-#			-font	=> $qfont,
+			-font	=> $sfont,
 #			-width	=> 30,
 #			-height	=> 2,
 			-command	=> sub {&snd_stop;&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$dlg->destroy; },
@@ -1249,6 +1269,7 @@ sub finish{
 	$dlg->raise;
 	$dlg->grab;
 	$dlg->focusForce;
+	$dlgbtn->focus;
 	$tl->lower($dlg);
 };
 
@@ -1273,6 +1294,32 @@ sub randomply{
 # Repositioning looks stupid.
 #	$dlg->idletasks;
 #	$dlg->geometry(sprintf "+%d+%d",($dlg->screenwidth-$dlg->width)/2,($dlg->screenheight-$dlg->height)/2);
+	$dlg->geometry(sprintf "+%d+%d",($dlg->screenwidth-100)/2,($dlg->screenheight-40)/2);
+
+	$dlg->raise;
+	$dlg->grab if ($force);
+	$dlg->focusForce if($force);
+	$q->focus;
+};
+
+sub random_ray{
+	my ($wid)=@_;
+	my $dlg=$wid->Toplevel;
+	$dlg->overrideredirect(1);
+
+	my $ply=int(rand($#players))+1;
+	$global_dbl_ply=$ply;
+
+	my $q=$dlg->Button(
+			-relief		=> "raised",
+			-border		=> 5,
+#			-background	=> $colors[$ply],
+			-foreground	=> "white",
+			-font       => $qfont,
+			-text		=> "Hey, ray!",
+			-command	=> sub {$wid->focusForce if ($force);$dlg->destroy},
+			)->pack();
+
 	$dlg->geometry(sprintf "+%d+%d",($dlg->screenwidth-100)/2,($dlg->screenheight-40)/2);
 
 	$dlg->raise;

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.7 2001/08/08 20:42:57 sec Exp sec $;
+	q$Id: beopardy,v 1.8 2001/08/10 13:53:59 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -231,7 +231,7 @@ if ($#ARGV>0){
 
 print SAV "[ply] ",join("/",@players),"\n";
 
-my @colors=qw(darkgrey darkred darkgreen darkblue);
+my @colors=qw(darkgrey darkred darkgreen darkblue cyan);
 
 unshift @players,"Nobody";
 my @points=(0)x($#players+1);
@@ -337,6 +337,12 @@ if(defined $readfile){
 	print "Reading Savegame...\n";
 	open(RSAV,$readfile) || die "Savegame error: $!";
 	while(<RSAV>){
+		if (/^\[ply\]/){
+			(undef,$ply)=split;
+			@players=split(/\//,$ply);
+			unshift @players,"Nobody";
+			next;
+		};
 		next if(! /^\[sav\]/);
 		(undef,$c,$f,$sgn,$ply)=split;
 		print "$c - $f - $sgn - $ply\n";
@@ -397,10 +403,10 @@ sub selectQuest{
 # XXX Pixmap-Hack. *funfunfun*
 
 	my ($i,$fnam);
-	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img):(.*?)\]/){
+	if ($jdata{$Cat[$c]}[$f] =~ s/^\[(img):(.*?)\]//){
 		$fnam=$2;
 		print "This is a $1 - $2\n";
-		$i= $tl->Pixmap($fnam,-file => $fnam.".xpm");
+		$i= $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
 	}
 
 	my $question;

--- a/beopardy
+++ b/beopardy
@@ -156,7 +156,12 @@ if ($tty){
 		print "connection from $name [", inet_ntoa($iaddr), "] at port $iport\n";
 	}else{
 		# Be sure to set device to -crtscts 19200
-		open(Client,"+>/dev/cuaU0") || die "open: $!";
+		open(Client,"+>/dev/ttyS0") || die "open: $!";
+		use IO::Stty;
+#		IO::Stty::stty(\*Client,"-crtscts");
+		IO::Stty::stty(\*Client,"19200");
+		IO::Stty::stty(\*Client,"-echo");
+		IO::Stty::stty(\*Client,"-icrnl");
 	};
 	print "done.\n";
 	autoflush Client;
@@ -275,30 +280,22 @@ my @points;
 # Here starts the Tk part...
 #my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
 #my $qfont=$tl->X11Font('-monotype-arial-medium-r-*-*-50-*-*-*-*-*-iso8859-*');
-my $qfont=$tl->X11Font('-monotype-arial-medium-r-*-*-50-*-*-*-*-*-iso8859-1');
+my $qfont=$tl->X11Font('-*-freesans-medium-r-*-*-50-*-*-*-*-*-iso8859-*');
 print "Question-Font:\n$qfont\n" if ($debug);
 
 #my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
 #my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-45-*-*-*-*-*-iso8859-1');
-my $tfont=$tl->X11Font('-monotype-times new roman-medium-r-*-*-60-*-*-*-*-*-iso8859-1');
+my $tfont=$tl->X11Font('-*-freesans-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
 print "Title-Font:\n$tfont\n" if($debug);
 
-my $sfont=$tl->X11Font('-monotype-courier new-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
+my $sfont=$tl->X11Font('-*-freemono-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
 print "Small-Font:\n$sfont\n" if($debug);
 
-my $fixedfont=$tl->X11Font('-monotype-courier new-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
+my $fixedfont=$tl->X11Font('-*-freemono-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
 print "Fixed-Font:\n$fixedfont\n" if($debug);
 
-#my $utf8font=$tl->X11Font('-jis-*-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
-#my $utf8font=$tl->X11Font('-monotype-courier new-medium-r-*-*-80-*-*-*-*-*-iso10646-1');
-my $utf8font=$tl->X11Font('-sec-sans-*-*-*-*-96-*-*-*-*-*-*-*');
+my $utf8font=$tl->X11Font('-*-freemono-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
 print "UTF8-Font:\n$utf8font\n" if($debug);
-
-my $secondfont=$tl->X11Font('-sec-jis-*-*-*-*-96-*-*-*-*-*-*-*');
-print "Second-Font:\n$secondfont\n" if($debug);
-
-my $kofont=$tl->X11Font('-sec-ko-*-*-*-*-96-*-*-*-*-*-*-*');
-print "ko-Font:\n$kofont\n" if($debug);
 
 unless ($qfont and $tfont and  $sfont ){
 	die "One or more fonts failed.\n";
@@ -308,6 +305,11 @@ $tl->configure(-height => $height, -width => $width);
 $tl->resizable(0,0);
 $tl->packPropagate(0);	# Keep the size.
 $tl->overrideredirect(1) if ($override);
+#$tl->fullscreen(1) if ($override);
+#$tl->attributes(-topmost => 'yes') if ($override);
+#$tl->highlightthickness(0) if ($override);
+#$tl->grabGlobal() if ($override);
+
 
 # Title of Gamefield
 my $tlabel = $tl -> Label (
@@ -543,6 +545,7 @@ sub ser_PlyEn {
 	if($tty){
 		$tl->fileevent(\*Client,'readable',[\&ser_SelectPly,@_]);
 		$dlgbtn->focus;
+		$dlgbtn->focusForce;
 	}else{
 		die "ser_en: $_[0]\n";
 	};
@@ -683,21 +686,11 @@ sub selectQuest{
 	}else{
 		my $txt=$jdata{$Cat[$c]}[$f];
 		my $magicfont=$qfont;
-
 	if ($txt =~ s/^\[fixed\]//){
 		$magicfont=$fixedfont;
 	};
 	if ($txt =~ s/^\[utf8\]//){
 		$txt=Encode::decode_utf8($txt);
-		$magicfont=$utf8font;
-	};
-	if ($txt =~ s/^\[sf\]//){
-		$txt=Encode::decode_utf8($txt);
-		$magicfont=$secondfont;
-	};
-	if ($txt =~ s/^\[ko\]//){
-		$txt=Encode::decode_utf8($txt);
-		$magicfont=$kofont;
 	};
 		if(defined($fnam)&&($typ eq "snd")){
 			if(!$soundd){$txt.="\n[ERR:Nosound]"};

--- a/beopardy
+++ b/beopardy
@@ -21,6 +21,7 @@ my $debug=0;
 my $override=0;					# Ignore windowmanager?
 my $force=0;					# move focus for kbd-mode?
 my $tty=0;						# use tty/serial input?
+my $splash=0;					# Display a splashscreen?
 my $socket=0;					# tty emulated by tcp socket?
 my $geometry=0;					# How big should I be?
 my $readfile;					# Should I read from a file?
@@ -37,6 +38,9 @@ my %ln = (
 
 sub _ {
 	my $key=shift;
+
+	return $key; # Deutsch-Mode.
+
 	if (defined ($ln{$key})){
 		return $ln{$key};
 	}else{
@@ -45,7 +49,7 @@ sub _ {
 };
 
 my %opt;
-getopts('doftsg:r:hw', \%opt);
+getopts('doftsg:r:hwb', \%opt);
 
 # Possible screen sizes
 my %screen=( 320 => 200,
@@ -67,6 +71,7 @@ beopardy -options Gamefile Player1 Player2 ...
 -f		Force keyboard focus.           (fullscreen)
 -t		Tty input. Use when Buzzers are connected.
 -s		Socket. Emulate Tty input via tcp socket (port 3333)
+-b		Beopardy splashscreen. Default for serial input.
 -r <file>	Read saved game from File.
 -w		Save game progress for reading with -r.
 -g <size>	geometry. Select window size.
@@ -86,6 +91,7 @@ $force=1	if (defined $opt{f});
 $tty=1		if (defined $opt{t});
 $socket=1	if (defined $opt{s});
 $savefile=1	if (defined $opt{w});
+$splash=1	if (defined $opt{b});
 
 if($opt{r}){ # Read savefile
 	if ( -f $opt{r} ){
@@ -94,6 +100,7 @@ if($opt{r}){ # Read savefile
 };
 
 if ($socket){$tty=1};	# socket emulates tty.
+if ($tty){$splash=1};	# tty requires splash.
 
 my $tl = MainWindow -> new -> toplevel;
 $tl->appname(beopardy);
@@ -158,7 +165,7 @@ while (<J>){
 		next;
 	}
 	$_.=" ";
-	if (!s/\\n/\n/){
+	if (!s/\\n/\n/g){
 		s/(.{10,$qwidth})\s+/$1\n/mg;
 	};
 	$jdata{$nam}[++$c]=$_;
@@ -205,8 +212,9 @@ sub read_game{
 	};
 	if ($p){
 		print "Hit enter to continue...\n";
-		$p=<>;
+		$p=<STDIN>;
 	};
+
 	if($savefile){
 		my($ts)=logname();
 		open(SAV,">$gamefile.$ts");
@@ -229,21 +237,20 @@ if ($#ARGV>0){
 	@players=qw(Foo Bar Baz);
 };
 
-print SAV "[ply] ",join("/",@players),"\n";
 
-my @colors=qw(darkgrey darkred darkgreen darkblue cyan);
+my @colors=qw(darkgrey darkred darkgreen darkblue darkcyan yellow);
 
 unshift @players,"Nobody";
-my @points=(0)x($#players+1);
+my @points;
 
 # Here starts the Tk part...
 #my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
 my $qfont=$tl->X11Font('-truetype-arial-medium-r-*-*-40-*-*-*-*-*-ascii-*');
 print "Question-Font:\n$qfont\n" if ($debug);
-my $qsfont=$tl->X11Font('-truetype-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
+#my $qsfont=$tl->X11Font('-truetype-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
 
 #my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
-my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-36-*-*-*-*-*-iso8859-1');
+my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-25-*-*-*-*-*-iso8859-1');
 print "Title-Font:\n$tfont\n" if($debug);
 
 $tl->configure(-height => $height, -width => $width);
@@ -267,12 +274,17 @@ my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
 my @button;	# The TkButtons 
 my @pts;	# Who got points from this question?
 my @frame;  # The TkFrames, one per category.
+my @mframe; # A frame per button to avoid stupid resizing.
 for my $cat (0..$#Cat){
-	$frame[$cat]=$bframe->Frame->pack(
+	$frame[$cat]=$bframe->Frame(
+			-width => 1,
+			-height => 1,
+	)->pack(
 			-side	=>'left',
 			-fill	=>'both',
 			-expand	=> 1,
 	);
+	$frame[$cat]->packPropagate(0);
 
 	$button[$cat][0] = $frame[$cat]->Label(
 			-width	=> $catwidth,
@@ -280,7 +292,11 @@ for my $cat (0..$#Cat){
 	)->pack(-fill	=> 'both');
 
 	for my $q (1..$q) {
-		$button[$cat][$q] = $frame[$cat]->Button(
+		$mframe[$cat][$q] = $frame[$cat]->Frame(
+				height => 1
+				)-> pack( -fill => 'both', -expand => 1);
+		$mframe[$cat][$q]->packPropagate(0);
+		$button[$cat][$q] = $mframe[$cat][$q]->Button(
 				-text		=> "${q}00",
 				-command	=> [\&selectQuest,$tl,$cat,$q],
 				-font		=> $tfont,
@@ -289,6 +305,7 @@ for my $cat (0..$#Cat){
 		$button[$cat][$q]->bind('<j>',[\&moveCrsr,$cat  ,$q+1]);
 		$button[$cat][$q]->bind('<k>',[\&moveCrsr,$cat  ,$q-1]);
 		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
+#		$button[$cat][$q]->bind('<e>',[\&edit_pts,$cat  ,$q  ]);
 # Fuer mh, der die VI-Keys nicht mag...
 		$button[$cat][$q]->bind('<Left>' ,[\&moveCrsr,$cat-1,$q  ]);
 		$button[$cat][$q]->bind('<Down>' ,[\&moveCrsr,$cat  ,$q+1]);
@@ -299,12 +316,14 @@ for my $cat (0..$#Cat){
 $button[0][1]->focus;
 #$button[0][1]->focusForce if ($force);
 
-# Scoreboard.
+sub scoreboard(){ # Scoreboard.
 my $sframe=$tl->Frame->pack(-side=>'top',-fill=>'x');
 my @pborder;
 my @pframes;
 my @pnames;
 my @pscores;
+
+@points=(0)x($#players+1);
 for (1..$#players){
 	if ($_ == $#players){
 		$pborder[$_]=$sframe;
@@ -329,6 +348,9 @@ for (1..$#players){
 			-anchor		=>'e',
 	)->pack(-fill=>'x');
 };
+return $sframe;
+print SAV "[ply] ",join("/",@players),"\n";
+};
 
 #print "Board done.\n";
 
@@ -351,24 +373,146 @@ if(defined $readfile){
 	close(RSAV);
 };
 
+my $sframe=scoreboard();
+
 print "\nGame start.\n\n";
 
-if($tty){
+my @elist;
+my $dlgbtn;
+
+my $splash_frame;
+$tl->waitVisibility; # To fix stacking order
+
+if($splash){ # Splash-Screen
 	my $dlg=$tl->Toplevel;
-	$dlg->Button(
+	my $i;
+	my $rframe;
+
+#	$dlg->configure(-height => $height, -width => $width);
+#	$dlg->resizable(0,0);
+#	$dlg->packPropagate(0);	# Keep the size.
+	$dlg->overrideredirect(1);
+	my $q=$dlg->Label(qw/-relief raised -width 80/)->pack;
+
+	$i= $q->Pixmap("beopardy",-file => "img/beopardy.xpm");
+
+	if(defined($i)){
+		$q->Label(-image=>"beopardy")->pack(-side=>"left");
+	};
+
+	$rframe=$q->Frame->pack(-fill=>'both',-expand=>1);
+
+	my $f = $rframe;
+	$splash_frame=$f;
+	my $row=0;
+	foreach (1..$#players) {
+		my $e = $f->Entry(qw/-relief sunken -width 40/);
+		$e->insert(0,$players[$_]);
+		if($tty){
+			$e->bind('<Return>',[\&ser_reset,\&ser_PlyEn]);
+		}else{
+			$e->bind('<Return>',[\&ply_focus,$_+1]);
+		};
+		$e->bind('<FocusOut>',[\&set_ply,$_]);
+
+		my $l = $f->Label(-text => "Player $_", 
+			-width		=> $namewidth,
+			-background	=> $colors[$_],
+			-foreground	=> "white",
+			-anchor 	=> 'e', -justify => 'right');
+		Tk::grid( $l, -row => $row, -column => 0, -sticky => 'e');
+		Tk::grid( $e, -row => $row++, -column => 1,-sticky => 'ew');
+		$f->gridRowconfigure(1,-weight => 1);  
+		$elist[$_]=$e;
+	}
+	$dlgbtn=$q->Button(
 			-text	=> "Start",
 			-font	=> $qfont,
-			-width	=> 30,
-			-height	=> 10,
-			-command	=> sub { $dlg->destroy;&ser_reset;$button[0][1]->focusForce if ($force)},
+#			-width	=> 30,
+			-height	=> 2,
+			-command	=> sub {&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$splash=0;$dlg->destroy;},
 	)->pack(
 			-fill	=>'x',
 			-expand	=>1,
 	);
+
+	if($tty){
+		&ser_PlyEn;
+	}else{
+		&ply_focus(".",1);
+	};
+
+	$dlg->idletasks;
+	$dlg->geometry(sprintf "+%d+%d",($dlg->screenwidth-$dlg->width)/2,($dlg->screenheight-$dlg->height)/2);
+
 	$dlg->raise;
 	$dlg->grab;
 	$dlg->focusForce;
 	$tl->lower($dlg);
+};
+
+sub set_ply {
+	my ($crap,$key)=@_;
+	print "set_ply $key\n" if($debug);
+	$players[$key]=$crap->get;
+};
+
+sub ser_PlyEn {
+	if($tty){
+		$tl->fileevent(\*Client,'readable',[\&ser_SelectPly,@_]);
+		$dlgbtn->focus;
+	}else{
+		die "ser_en: $_[0]\n";
+	};
+};
+
+sub ply_focus {
+	my ($crap, $key)=@_;
+	if ($key>$#players){
+		if($tty && ($key==($#players+1))){
+			my $f=$splash_frame;
+			my $row=$key-1;
+			$players[$key]="New Player $key";
+			my $e = $f->Entry(qw/-relief sunken -width 40/);
+			$e->insert(0,$players[$key]);
+			$e->bind('<Return>',[\&ser_reset,\&ser_PlyEn]);
+			$e->bind('<FocusOut>',[\&set_ply,$key]);
+
+			my $l = $f->Label(-text => "Player $key", 
+					-width		=> $namewidth,
+					-background	=> $colors[$key],
+					-foreground	=> "white",
+					-anchor 	=> 'e', -justify => 'right');
+			Tk::grid( $l, -row => $row, -column => 0, -sticky => 'e');
+			Tk::grid( $e, -row => $row++, -column => 1,-sticky => 'ew');
+			$f->gridRowconfigure(1,-weight => 1);  
+			$elist[$key]=$e;
+			$elist[$key]->focus;
+			$elist[$key]->selectionRange(0,'end');
+			$sframe->destroy;
+			$sframe=scoreboard();
+			$sframe->idletasks;
+			return;
+		};
+		$dlgbtn->focus;
+	}else{
+		$elist[$key]->focus;
+		$elist[$key]->selectionRange(0,'end');
+	};
+};
+
+sub ser_SelectPly {
+	my ($crap)=@_;
+
+	my $key=<Client>;
+	$key=~s/\r?\n$//;
+	$key=$key+0;
+	if($key == 0){
+		&ser_reset;
+	}else{
+		&ply_focus(".",$key);
+		&ser_dis;
+	};
 };
 
 # Make the 'resetting' window...
@@ -378,6 +522,8 @@ $reset->resizable(0,0);
 $reset->geometry("-0+0");
 $reset->withdraw;
 $reset->Label(-text=>"resetting",-background=>"green")->pack;
+
+$tl->after(100,\&ser_reset) if($tty);
 
 MainLoop;
 
@@ -389,6 +535,9 @@ sub selectQuest{
 
 	my $tl = $otl->Toplevel;
 	$tl->configure(-height => $height, -width => $width);
+	if(!$override){ # XXX my windowmanager is broken %)
+		$tl->geometry("+".($otl->rootx-28)."+".($otl->rooty-9));
+	};
 	$tl->resizable(0,0);
 	$tl->packPropagate(0);	# Keep the size.
 	$tl->overrideredirect(1) if($override);
@@ -418,6 +567,7 @@ sub selectQuest{
 		$question = $tl->Label(
 			-text	=> $jdata{$Cat[$c]}[$f],
 			-font	=> $qfont,
+			-justify	=> "left",
 		);
 	};
 
@@ -552,14 +702,14 @@ sub updPlayfield {
 	if($col<0){$col=0};
 	$col=$colors[$col];
 #	print ">$pl<\n";
-#	my $oheight=$button[$c][$f]->height;
+#	my $oheight=$button[$c][$f]->height; print "$c/$f: $oheight\n";
 	$button[$c][$f]->configure(
 			-text				=> $pl,
 			-relief				=> "flat",
 			-foreground			=>'grey',
 			-activeforeground	=>'grey',
-			-height				=> 1,
-			-width				=> 1,
+			-height				=> 0,
+			-width				=> 0,
 			-background			=> $col,
 			-font				=> $qfont,
 	);
@@ -604,6 +754,9 @@ sub ser_reset{
 	$reset->withdraw;
 #	$tl->focusForce if ($force);
 	&$quux;
+	if($splash){
+		&ser_PlyEn;
+	};
 };
 
 sub ser_noinp{

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.11 2002/12/28 15:02:40 sec Exp sec $;
+	q$Id: beopardy,v 1.12 2003/12/31 23:28:30 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -30,6 +30,11 @@ my $readfile;					# Should I read from a file?
 my $savefile=0;					# Should I save to a file?
 
 my $global_question_inhibit=0;
+
+my $global_is_dbl=0;
+my $global_dbl_maxamt=0;
+my $global_dbl_amt=0;
+my $global_dbl_ply=0;
 
 # L10n
 my %ln = (
@@ -389,6 +394,10 @@ if(defined $readfile){
 #			unshift @players,"Nobody";
 			next;
 		};
+		if(/^\[DBL\] (\d+)/){
+			$global_dbl_amt=$1;
+			$global_is_dbl=1;
+		};
 		next if(! /^\[sav\]/);
 		(undef,$c,$f,$sgn,$ply)=split;
 		print "$c - $f - $sgn - $ply\n";
@@ -568,6 +577,15 @@ sub selectQuest{
 	return if $global_question_inhibit;
 	print "Q$f / \"$Cat[$c]\":\n$jdata{$Cat[$c]}[$f]\n";
 
+	if( $jdata{$Cat[$c]}[$f] =~ s/\s*\[dbl\]\s*// && $global_is_dbl == 0){
+		$global_is_dbl=1;
+		&enterdbl;
+		return;
+	};
+	if($global_is_dbl == 1){
+		$_[3]->destroy;
+	};
+
 	my $tl = $otl->Toplevel;
 	$tl->fileevent(\*Client,'readable',"");
 	$tl->configure(-height => $height, -width => $width);
@@ -591,7 +609,7 @@ sub selectQuest{
 	$typ="";
 	print $jdata{$Cat[$c]}[$f]," <-\n";
 	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img|snd):(.*?)\]\s*/){
-		print "JA\n";
+#		print "JA\n";
 		$typ=$1;$fnam=$2;
 		print "This is of $typ - \'$2\'\n";
 		if($typ eq "img"){
@@ -642,8 +660,14 @@ sub selectQuest{
 
 	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
 
+	print("Hello $global_is_dbl \n");
 
-	$tl->afterIdle(sub {&ser_en($tl,$c,$f) if ($tty);}); # fix Bug#2
+	$tl->waitVisibility; # To fix stacking order
+	if($global_is_dbl){
+		$tl->afterIdle(sub {&ser_answerQuest($tl,$c,$f) if ($tty);});
+	}else{
+		$tl->afterIdle(sub {&ser_en($tl,$c,$f) if ($tty);}); # fix Bug#2
+	};
 };
 
 my @cur_ser_answer=undef;
@@ -651,10 +675,14 @@ my @cur_ser_answer=undef;
 sub ser_answerQuest {
 	my ($crap,$c,$f)=@_;
 
-	my $key=<Client>;
+	my $key;
+	if($global_is_dbl==1){
+		$key=$global_dbl_ply;
+	}else{
+		$key=<Client>;
+	};
 	print "SER<: <$key>\n" if($debug);
 
-#	&snd_play("think",1);
 	&snd_stop if($snd_save);
 
 	$key=~s/\r?\n$//;
@@ -776,6 +804,7 @@ sub answerQuest{
 		$crap->destroy;
 		&ser_dis if ($tty);  # "input nach 'q' auf frage" fix.
 		$button[$c][$f]->focusForce if ($force);
+		$global_dbl_ply=0; # Nobody has the tag...
 		return;
 	};
 	&snd_stop() if ($key eq "0"); # XXX
@@ -807,8 +836,17 @@ sub answerQuest{
 sub updPlayfield {
 	my ($c,$f,$key,$sgn)=@_;
 	print $sgn<0?"bad":"good"," for ",$players[$key],"\n";
+	print SAV "[DBL] $global_dbl_amt\n" if ($global_is_dbl);
 	print SAV "[sav] $c $f $sgn $key\n";
-	$points[$key]+=$sgn*$f*100;
+	if($global_is_dbl){
+		$points[$key]+=$sgn*$global_dbl_amt;
+		$global_is_dbl=0;
+	}else{
+		$points[$key]+=$sgn*$f*100;
+	};
+	if($sgn>0){
+		$global_dbl_ply=$key;
+	}; # cache player who has the tag....
 	
 	push @{$pts[$c][$f]},$sgn*$key;
 	my $pl=join("\n",map {($_<0?"-":" ").$players[abs]} @{$pts[$c][$f]});
@@ -935,3 +973,80 @@ sub snd_color {
 	};
 
 };
+
+sub enterdbl {
+	my ($crap,$c,$f)=@_;
+
+	my $ich=$crap->Toplevel;
+
+	$global_dbl_maxamt=100*$f*2;
+	$global_dbl_amt=100*$f;
+
+	$ich->overrideredirect(1) if($override);
+	$ich->resizable(0,0);
+	$ich->geometry("-0-0");
+
+
+	my $ftl = $ich->Frame( -relief => 'ridge', -bd => 4)->pack;
+	my $ttl=$ftl->Label(
+			-text	=> "Double Jeopardy",
+			-font	=> $qfont,
+	)->pack(
+			-fill	=>'x',
+			-expand	=> 1,
+	);
+	my $ply=$ftl->Label(
+			-text	=> $players[$global_dbl_ply],
+			-background	=> $colors[$global_dbl_ply],
+			-font	=> $qfont,
+	)->pack(
+			-fill	=>'x',
+			-expand	=> 1,
+	);
+	my $amnt=$ftl->Label(
+			-textvar	=> \$global_dbl_amt,
+			-font	=> $qfont,
+	)->pack(
+			-fill	=>'x',
+			-expand	=> 1,
+	);
+	
+	my $bframe=$ftl->Frame->pack(-fill=>'both',-expand=>1);
+
+	my $br=$bframe->Button(
+			-text		=> _('Ok'),
+			-command	=> sub{
+#							printf("reenter selQ?");
+							&selectQuest($crap,$c,$f,$ich);
+							},
+	)->pack(-fill	=>'x', -expand => 1);
+
+	$br->bind('<j>',sub{&amt_chg(-50)});
+	$br->bind('<k>',sub{&amt_chg(+50)});
+	$br->bind('<l>',sub{&dblplychg($ply,+1)});
+	$br->bind('<h>',sub{&dblplychg($ply,-1)});
+# inzwischen ist Nick der faule hier.
+	$br->bind('<Right>',sub{&dblplychg($ply,+1)});
+	$br->bind('<Left>',sub{&dblplychg($ply,-1)});
+	$br->bind('<Up>',sub{&amt_chg(+50)});
+	$br->bind('<Down>',sub{&amt_chg(-50)});
+
+	$br->focus;
+	$br->focusForce if($force);
+};
+
+sub amt_chg{
+	$global_dbl_amt+=shift;
+	if($global_dbl_amt<0){$global_dbl_amt=0};
+	if($global_dbl_amt>$global_dbl_maxamt){$global_dbl_amt=$global_dbl_maxamt};
+};
+
+sub dblplychg{
+	my($ply,$dir)=@_;
+	$global_dbl_ply+=$dir;
+	$global_dbl_ply=$#players if($global_dbl_ply<1);
+	$global_dbl_ply=1 if ($global_dbl_ply>$#players);
+	$ply->configure(-text => $players[$global_dbl_ply],
+			-background	=> $colors[$global_dbl_ply]);
+};
+

--- a/beopardy
+++ b/beopardy
@@ -289,8 +289,16 @@ print "Small-Font:\n$sfont\n" if($debug);
 my $fixedfont=$tl->X11Font('-monotype-courier new-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
 print "Fixed-Font:\n$fixedfont\n" if($debug);
 
-my $utf8font=$tl->X11Font('-jis-*-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
+#my $utf8font=$tl->X11Font('-jis-*-medium-r-*-*-20-*-*-*-*-*-iso8859-1');
+#my $utf8font=$tl->X11Font('-monotype-courier new-medium-r-*-*-80-*-*-*-*-*-iso10646-1');
+my $utf8font=$tl->X11Font('-sec-sans-*-*-*-*-96-*-*-*-*-*-*-*');
 print "UTF8-Font:\n$utf8font\n" if($debug);
+
+my $secondfont=$tl->X11Font('-sec-jis-*-*-*-*-96-*-*-*-*-*-*-*');
+print "Second-Font:\n$secondfont\n" if($debug);
+
+my $kofont=$tl->X11Font('-sec-ko-*-*-*-*-96-*-*-*-*-*-*-*');
+print "ko-Font:\n$kofont\n" if($debug);
 
 unless ($qfont and $tfont and  $sfont ){
 	die "One or more fonts failed.\n";
@@ -675,11 +683,21 @@ sub selectQuest{
 	}else{
 		my $txt=$jdata{$Cat[$c]}[$f];
 		my $magicfont=$qfont;
+
 	if ($txt =~ s/^\[fixed\]//){
 		$magicfont=$fixedfont;
 	};
 	if ($txt =~ s/^\[utf8\]//){
 		$txt=Encode::decode_utf8($txt);
+		$magicfont=$utf8font;
+	};
+	if ($txt =~ s/^\[sf\]//){
+		$txt=Encode::decode_utf8($txt);
+		$magicfont=$secondfont;
+	};
+	if ($txt =~ s/^\[ko\]//){
+		$txt=Encode::decode_utf8($txt);
+		$magicfont=$kofont;
 	};
 		if(defined($fnam)&&($typ eq "snd")){
 			if(!$soundd){$txt.="\n[ERR:Nosound]"};

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.8 2001/08/10 13:53:59 sec Exp sec $;
+	q$Id: beopardy,v 1.9 2001/12/26 14:35:57 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -34,6 +34,7 @@ my %ln = (
 		"Oops"				=> "oops",
 		"ist etwas unruhig"	=> "seems a bit nervous",
 		"Knopf loesen"		=> "release your button",
+		"nochmal"			=> "try again",
 		);
 
 sub _ {
@@ -165,9 +166,10 @@ while (<J>){
 		next;
 	}
 	$_.=" ";
-	if (!s/\\n/\n/g){
+	if (!s/(?<!\\)\\n/\n/g){
 		s/(.{10,$qwidth})\s+/$1\n/mg;
 	};
+	s/\\\\/\\/mg;
 	$jdata{$nam}[++$c]=$_;
 };
 close(J);
@@ -316,6 +318,7 @@ for my $cat (0..$#Cat){
 $button[0][1]->focus;
 #$button[0][1]->focusForce if ($force);
 
+@points=(0)x(4);
 sub scoreboard(){ # Scoreboard.
 my $sframe=$tl->Frame->pack(-side=>'top',-fill=>'x');
 my @pborder;
@@ -323,7 +326,6 @@ my @pframes;
 my @pnames;
 my @pscores;
 
-@points=(0)x($#players+1);
 for (1..$#players){
 	if ($_ == $#players){
 		$pborder[$_]=$sframe;
@@ -348,8 +350,8 @@ for (1..$#players){
 			-anchor		=>'e',
 	)->pack(-fill=>'x');
 };
-return $sframe;
 print SAV "[ply] ",join("/",@players),"\n";
+return $sframe;
 };
 
 #print "Board done.\n";
@@ -362,7 +364,7 @@ if(defined $readfile){
 		if (/^\[ply\]/){
 			(undef,$ply)=split;
 			@players=split(/\//,$ply);
-			unshift @players,"Nobody";
+#			unshift @players,"Nobody";
 			next;
 		};
 		next if(! /^\[sav\]/);
@@ -383,6 +385,7 @@ my $dlgbtn;
 my $splash_frame;
 $tl->waitVisibility; # To fix stacking order
 
+
 if($splash){ # Splash-Screen
 	my $dlg=$tl->Toplevel;
 	my $i;
@@ -397,7 +400,7 @@ if($splash){ # Splash-Screen
 	$i= $q->Pixmap("beopardy",-file => "img/beopardy.xpm");
 
 	if(defined($i)){
-		$q->Label(-image=>"beopardy")->pack(-side=>"left");
+		$q->Label(-image=>"beopardy")->pack(-side=>"top");
 	};
 
 	$rframe=$q->Frame->pack(-fill=>'both',-expand=>1);
@@ -430,7 +433,9 @@ if($splash){ # Splash-Screen
 			-font	=> $qfont,
 #			-width	=> 30,
 			-height	=> 2,
-			-command	=> sub {&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$splash=0;$dlg->destroy;},
+			-command	=> sub {$splash=0;&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$dlg->destroy;
+			print SAV "[ply] ",join("/",@players),"\n";
+			},
 	)->pack(
 			-fill	=>'x',
 			-expand	=>1,
@@ -529,6 +534,8 @@ MainLoop;
 
 # We selected a question...
 
+my %imgcache;
+
 sub selectQuest{
 	my ($otl,$c,$f)=@_;
 	print "Q$f / \"$Cat[$c]\":\n$jdata{$Cat[$c]}[$f]\n";
@@ -552,14 +559,16 @@ sub selectQuest{
 # XXX Pixmap-Hack. *funfunfun*
 
 	my ($i,$fnam);
-	if ($jdata{$Cat[$c]}[$f] =~ s/^\[(img):(.*?)\]//){
+	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img):(.*?)\]/){
 		$fnam=$2;
 		print "This is a $1 - $2\n";
-		$i= $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
+		if(!defined($imgcache{$fnam})){
+			$imgcache{$fnam} = $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
+		};
 	}
 
 	my $question;
-	if (defined $i){
+	if (defined($fnam) && defined($imgcache{$fnam})){
 		$question = $tl->Label(
 			-image	=> "$fnam",
 		);
@@ -776,7 +785,7 @@ sub ser_fatal{
 
 	my $answer = $tl->Dialog(-title => "ser_junk",
 			-textvar => \$fatal,
-			-buttons => [ "try again" ],
+			-buttons => [ _("nochmal") ],
 			);
 	$answer->overrideredirect(1);
 	$answer->focusForce;

--- a/beopardy
+++ b/beopardy
@@ -315,7 +315,7 @@ for my $cat (0..$#Cat){
 
 	for my $q (1..$q) {
 		$mframe[$cat][$q] = $frame[$cat]->Frame(
-#				height => 1
+				height => 1
 				)-> pack( -fill => 'both', -expand => 1);
 		$mframe[$cat][$q]->packPropagate(0);
 		$button[$cat][$q] = $mframe[$cat][$q]->Button(

--- a/beopardy
+++ b/beopardy
@@ -287,24 +287,19 @@ unshift @players,"Nobody";
 my @points;
 
 # Here starts the Tk part...
-#my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
-#my $qfont=$tl->X11Font('-monotype-arial-medium-r-*-*-50-*-*-*-*-*-iso8859-*');
-my $qfont=$tl->X11Font('-*-freesans-medium-r-*-*-50-*-*-*-*-*-iso8859-*');
+my $qfont=$tl->X11Font('-*-arial-medium-r-*-*-60-*-*-*-*-*-iso8859-*');
 print "Question-Font:\n$qfont\n" if ($debug);
 
-#my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
-#my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-45-*-*-*-*-*-iso8859-1');
-my $tfont=$tl->X11Font('-*-freesans-medium-r-*-*-40-*-*-*-*-*-iso8859-*');
+my $tfont=$tl->X11Font('-*-verdana-medium-r-*-*-50-*-*-*-*-*-iso8859-*');
 print "Title-Font:\n$tfont\n" if($debug);
 
-#my $sfont=$tl->X11Font('-*-freemono-medium-r-*-*-10-*-*-*-*-*-iso8859-*');
-my $sfont=$tl->X11Font('-*-freesans-medium-r-*-*-20-*-*-*-*-*-iso8859-*');
+my $sfont=$tl->X11Font('-*-arial-medium-r-*-*-25-*-*-*-*-*-iso8859-*');
 print "Small-Font:\n$sfont\n" if($debug);
 
-my $fixedfont=$tl->X11Font('-*-freemono-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
+my $fixedfont=$tl->X11Font('-*-courier 10 pitch-medium-r-*-*-70-*-*-*-*-*-iso8859-*');
 print "Fixed-Font:\n$fixedfont\n" if($debug);
 
-my $utf8font=$tl->X11Font('-*-freemono-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
+my $utf8font=$tl->X11Font('-*-arial-medium-r-*-*-30-*-*-*-*-*-iso8859-*');
 print "UTF8-Font:\n$utf8font\n" if($debug);
 
 unless ($qfont and $tfont and  $sfont ){
@@ -314,9 +309,11 @@ unless ($qfont and $tfont and  $sfont ){
 $tl->configure(-height => $height, -width => $width);
 $tl->resizable(0,0);
 $tl->packPropagate(0);	# Keep the size.
-$tl->overrideredirect(1) if ($override);
+#$tl->overrideredirect(1) if ($override);
+$tl->focus if ($override);
 #$tl->fullscreen(1) if ($override);
-#$tl->attributes(-topmost => 'yes') if ($override);
+$tl->attributes(-topmost => 'yes') if ($override);
+$tl->attributes(-fullscreen => 'yes') if ($override);
 #$tl->highlightthickness(0) if ($override);
 #$tl->grabGlobal() if ($override);
 

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.10 2002/12/23 15:45:13 sec Exp sec $;
+	q$Id: beopardy,v 1.11 2002/12/28 15:02:40 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -315,7 +315,7 @@ for my $cat (0..$#Cat){
 
 	for my $q (1..$q) {
 		$mframe[$cat][$q] = $frame[$cat]->Frame(
-				height => 1
+#				height => 1
 				)-> pack( -fill => 'both', -expand => 1);
 		$mframe[$cat][$q]->packPropagate(0);
 		$button[$cat][$q] = $mframe[$cat][$q]->Button(
@@ -417,6 +417,7 @@ if($splash){ # Splash-Screen
 	$dlg->overrideredirect(1);
 	my $q=$dlg->Label(qw/-relief raised -width 80/)->pack;
 
+	snd_play("start");
 	$i= $q->Pixmap("beopardy",-file => "img/beopardy.xpm");
 
 	if(defined($i)){
@@ -453,7 +454,7 @@ if($splash){ # Splash-Screen
 			-font	=> $qfont,
 #			-width	=> 30,
 			-height	=> 2,
-			-command	=> sub {$splash=0;&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$dlg->destroy;
+			-command	=> sub {$splash=0;&snd_stop;&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$dlg->destroy;
 			print SAV "[ply] ",join("/",@players),"\n";
 			},
 	)->pack(
@@ -498,6 +499,7 @@ sub ply_focus {
 			my $f=$splash_frame;
 			my $row=$key-1;
 			$players[$key]="New Player $key";
+			$points[$key]=0;
 			my $e = $f->Entry(qw/-relief sunken -width 40/);
 			$e->insert(0,$players[$key]);
 			$e->bind('<Return>',[\&ser_reset,\&ser_PlyEn]);
@@ -520,6 +522,7 @@ sub ply_focus {
 			return;
 		};
 		$dlgbtn->focus;
+#		$dlgbtn->focusForce if($force);
 	}else{
 		$elist[$key]->focus;
 		$elist[$key]->selectionRange(0,'end');
@@ -583,13 +586,18 @@ sub selectQuest{
 # XXX Pixmap-Hack. *funfunfun*
 
 	my ($typ,$fnam);
+	$typ="";
+	print $jdata{$Cat[$c]}[$f]," <-\n";
 	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img|snd):(.*?)\]\s*/){
+		print "JA\n";
 		$typ=$1;$fnam=$2;
 		print "This is of $typ - \'$2\'\n";
 		if($typ eq "img"){
 			if(!defined($imgcache{$fnam})){
 				if(-f "img/".$fnam.".xpm"){
 					$imgcache{$fnam} = $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
+				}else{
+					print "img/".$fnam.".xpm not found\n";
 				};
 			};
 		};

--- a/beopardy
+++ b/beopardy
@@ -630,11 +630,13 @@ MainLoop;
 # We selected a question...
 
 my %imgcache;
+my $wrong_answers; # count wrong answers, so we can close the question after last player
 
 sub selectQuest{
 	my ($otl,$c,$f)=@_;
 	print "global_question_inhibit= $global_question_inhibit\n";
 	return if $global_question_inhibit;
+	$wrong_answers = 0;
 	print "Q$f / \"$Cat[$c]\":\n$jdata{$Cat[$c]}[$f]\n";
 
 	if( $jdata{$Cat[$c]}[$f] =~ s/\s*\[dbl\]\s*// && $global_is_dbl == 0){
@@ -908,9 +910,18 @@ sub answerQuest{
 		};
 		if ($key <= $#players){
 			&updPlayfield($c,$f,$key,$sgn);
-			$crap->destroy if ($sgn>0);
+			if ($sgn>0) {
+				$crap->destroy;
+				$button[$c][$f]->focusForce if $force);
+			} elsif($sgn<0) {
+				$wrong_answers++;
+				if($wrong_answers >= $#players) {
+					# all players gave a wrong answer, close the question
+					$crap->destroy;
+					$button[$c][$f]->focusForce if ($force);
+				}
+			}
 			&ser_reset if ($tty);
-			$button[$c][$f]->focusForce if ($force && ($sgn>0));
 #			&snd_stop(0);
 			return;
 		};

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.9 2001/12/26 14:35:57 sec Exp sec $;
+	q$Id: beopardy,v 1.10 2002/12/23 15:45:13 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -27,6 +27,8 @@ my $socket=0;					# tty emulated by tcp socket?
 my $geometry=0;					# How big should I be?
 my $readfile;					# Should I read from a file?
 my $savefile=0;					# Should I save to a file?
+
+my $global_question_inhibit=0;
 
 # L10n
 my %ln = (
@@ -528,6 +530,7 @@ sub ser_SelectPly {
 	my ($crap)=@_;
 
 	my $key=<Client>;
+	print "SER<: <$key>\n";
 	$key=~s/\r?\n$//;
 	$key=$key+0;
 	if($key == 0){
@@ -556,9 +559,12 @@ my %imgcache;
 
 sub selectQuest{
 	my ($otl,$c,$f)=@_;
+	print "global_question_inhibit= $global_question_inhibit\n";
+	return if $global_question_inhibit;
 	print "Q$f / \"$Cat[$c]\":\n$jdata{$Cat[$c]}[$f]\n";
 
 	my $tl = $otl->Toplevel;
+	$tl->fileevent(\*Client,'readable',"");
 	$tl->configure(-height => $height, -width => $width);
 	if(!$override){ # XXX my windowmanager is broken %)
 		$tl->geometry("+".($otl->rootx-28)."+".($otl->rooty-9));
@@ -577,15 +583,20 @@ sub selectQuest{
 # XXX Pixmap-Hack. *funfunfun*
 
 	my ($typ,$fnam);
-	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img|snd):(.*?)\]/){
+	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img|snd):(.*?)\]\s*/){
 		$typ=$1;$fnam=$2;
 		print "This is of $typ - \'$2\'\n";
 		if($typ eq "img"){
 			if(!defined($imgcache{$fnam})){
-				$imgcache{$fnam} = $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
+				if(-f "img/".$fnam.".xpm"){
+					$imgcache{$fnam} = $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
+				};
 			};
 		};
 	}
+	if ($typ ne "snd"){
+		&snd_play("think",1);
+	};
 
 	$snd_save=undef;
 	my $question;
@@ -593,17 +604,20 @@ sub selectQuest{
 		$question = $tl->Label(
 			-image	=> "$fnam",
 		);
-	}elsif(defined($fnam)&&($typ eq "snd")){
-		$question = $tl->Label(
-			-text	=> "listen...",
-			-font	=> $qfont,
-			-justify	=> "left",
-		);
-		&snd_play($fnam);
-		$snd_save=$fnam;
 	}else{
+		my $txt=$jdata{$Cat[$c]}[$f];
+		if(defined($fnam)&&($typ eq "snd")){
+			if(!$soundd){$txt.="\n[ERR:Nosound]"};
+			&snd_play($fnam);
+			$snd_save=$fnam;
+		};
+		if($txt=~s/^\[(\w+):.*?\]\s*//){
+			if(!$txt){
+				$txt="Err. This should be of type $1";
+			};
+		};
 		$question = $tl->Label(
-			-text	=> $jdata{$Cat[$c]}[$f],
+			-text	=> $txt,
 			-font	=> $qfont,
 			-justify	=> "left",
 		);
@@ -617,6 +631,8 @@ sub selectQuest{
 	$tl->focusForce if ($force);
 
 	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
+
+
 	$tl->afterIdle(sub {&ser_en($tl,$c,$f) if ($tty);}); # fix Bug#2
 };
 
@@ -626,8 +642,9 @@ sub ser_answerQuest {
 	my ($crap,$c,$f)=@_;
 
 	my $key=<Client>;
+	print "SER<: <$key>\n";
 
-	&snd_play("think",1);
+#	&snd_play("think",1);
 
 	$key=~s/\r?\n$//;
 
@@ -652,6 +669,7 @@ sub ser_answerQuest {
 	my $br=$bframe->Button(
 			-text		=> _('Richtig'),
 			-command	=> sub{
+							&snd_stop;
 							&answerQuest($crap,$c,$f,$key)
 							},
 	)->pack(-side	=>'left');
@@ -660,7 +678,7 @@ sub ser_answerQuest {
 			-command	=> sub{
 							$ich->destroy;
 							&answerQuest($crap,$c,$f,-$key);
-							&snd_resume;
+#							&snd_resume;
 							$crap->focusForce if ($force);
 							&ser_en($crap,$c,$f)},
 	)->pack(-side	=>'left');
@@ -668,8 +686,8 @@ sub ser_answerQuest {
 			-text		=> _('Oops'),
 			-command	=> sub{$ich->destroy;
 							  &ser_reset;
-							  &snd_stop;
-							  &snd_resume;
+#							  &snd_stop;
+#							  &snd_resume;
 							  $crap->focusForce if ($force);
 							  &ser_en($crap,$c,$f)},
 	)->pack;
@@ -738,13 +756,14 @@ sub answerQuest{
 	my ($crap,$c,$f,$key)=@_;
 	print "answered: $c $f $key\n";
 	my $sgn=1;
-	if($key eq "q"){
+	if(lc($key) =~ "q"){
 		&snd_stop(0);
 		$crap->destroy;
 		&ser_dis if ($tty);  # "input nach 'q' auf frage" fix.
 		$button[$c][$f]->focusForce if ($force);
 		return;
 	};
+	&snd_stop() if ($key eq "0"); # XXX
 	my $pos;
 	$key=-$pos if (($pos=index('0!"#$%&/()',$key))>0);
 	$key=-3  if($key eq '§');
@@ -763,7 +782,7 @@ sub answerQuest{
 			$crap->destroy if ($sgn>0);
 			&ser_reset if ($tty);
 			$button[$c][$f]->focusForce if ($force && ($sgn>0));
-			&snd_stop(0);
+#			&snd_stop(0);
 			return;
 		};
 	};
@@ -820,7 +839,9 @@ sub ser_reset{
 	do {
 		&ser_dis;
 		print Client "R\r\n";
+	print "SER>: R\n";
 		$ok=<Client>;
+	print "SER<: <$ok>\n";
 		$ok=~s/\r?\n//;
 		if ($ok ne "A"){
 			if ($ok =~ /(\d)/) {
@@ -854,6 +875,7 @@ sub ser_fatal{
 #	print "froobel: ",$quux,"\n";
 
 	$tl->fileevent(\*Client,'readable',[\&ser_eat,\$fatal]);
+	print "ser_fatal: $fatal\n";
 
 	my $answer = $tl->Dialog(-title => "ser_junk",
 			-textvar => \$fatal,
@@ -861,7 +883,9 @@ sub ser_fatal{
 			);
 	$answer->overrideredirect(1);
 	$answer->focusForce;
+	$global_question_inhibit=1;
 	$answer->Show();
+	$global_question_inhibit=0;
 	&$quux;
 };
 
@@ -869,6 +893,7 @@ sub ser_fatal{
 sub ser_eat {
 	my $ref=shift;
 	my $foo=scalar(<Client>);
+	print "SER<: <$foo>\n";
 	print "got: ",$foo;
 	$foo=~s/\r?\n//;
 	if($foo =~ /^\d+$/){
@@ -888,9 +913,9 @@ sub snd_color {
 	my $foo=scalar(<Soundd>);
 	print "Cgot: ",$foo;
 	if($foo=~/^E/){
-		$cur_ser_answer[0]->configure(
-			-background			=> "red",
-				);
+#		$cur_ser_answer[0]->configure(
+#			-background			=> "red",
+#				);
 	};
 
 };

--- a/beopardy
+++ b/beopardy
@@ -4,22 +4,47 @@
 
 # This code is under the BSD Licence
 # (c) by Stefan `Sec` Zehl <sec@42.org>
-# $Id$
-
-# based on snippets of romanclock by Abigail
+# $Id: beopardy,v 1.1 2000/12/04 02:48:47 sec Exp sec $
 
 use strict;
 use Tk;
 use Tk::Font;
 use Tk::X11Font;
+use Socket;
+use FileHandle;
 
 my $debug=1;
 my $override=0;					# Ignore windowmanager?
-my $force=1;					# move focus for kbd-mode?
+my $force=0;					# move focus for kbd-mode?
+my $tty=1;						# tty/serial input active?
+my $ser=1;						# tty/serial chooser.
+my $socket=1;					# tty emulated by tcp socket?
 
 my ($width,$height)=(640,480);	# Size of game field.
 my $catwidth =10;				# Width of categories.
 my $namewidth=10;				# Width of player names
+my $ser_inhibit=0;				# Global 'no input on serial now'
+
+if ($tty){
+print "Opening tty\n";
+if(!$ser){
+my $port = 3333;
+my $proto = getprotobyname('tcp');
+socket(Server, PF_INET, SOCK_STREAM, $proto)        || die "socket: $!";
+setsockopt(Server, SOL_SOCKET, SO_REUSEADDR, pack("l", 1))   || die "setsockopt: $!";
+bind(Server, sockaddr_in($port, INADDR_ANY))        || die "bind: $!" ;
+listen(Server,SOMAXCONN)                            || die "listen: $ !";
+print "Connect to port $port...\n";
+my $paddr = accept(Client,Server);
+my($iport,$iaddr) = sockaddr_in($paddr);
+my $name = gethostbyaddr($iaddr,AF_INET);
+print "connection from $name [", inet_ntoa($iaddr), "] at port $iport";
+}else{
+	open(Client,"+>/dev/cuaa0") || die;
+};
+print "done.\n";
+autoflush Client;
+};
 
 print "Reading questions....\n";
 my %jdata;
@@ -43,7 +68,7 @@ close(J);
 printf "%-20s:%2d\n",$nam,$c if ($debug);
 print "Totalling ",(scalar keys %jdata)," categories.\n";
 
-my @players=qw(Foo Bar Baz);
+my @players=qw(Christoph Chris Nick);
 my @points=(0,0,0);
 
 unshift @players,"Nobody";
@@ -104,6 +129,9 @@ $tl->bind('<<quit>>',sub{print "Done:\n",map {sprintf "%10s:%5d\n",$players[$_],
 sub selectQuest;
 sub answerQuest;
 sub moveCrsr;
+sub ser_reset;
+
+&ser_reset;
 
 # Game-Buttons.
 my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
@@ -181,31 +209,48 @@ sub selectQuest{
 	$tl->packPropagate(0);	# Keep the size.
 	$tl->overrideredirect(1) if($override);
 
-		my $tlabel = $tl->Label(
-				-text	=> $Cat[$c],
-				-relief	=> 'ridge',
-				-font	=> $tfont,
-		) -> pack(-fill	=> 'x');
+	my $tlabel = $tl->Label(
+			-text	=> $Cat[$c],
+			-relief	=> 'ridge',
+			-font	=> $tfont,
+	) -> pack(-fill	=> 'x');
 
-		my $text;
-		($text=$jdata{$Cat[$c]}[$f])=~ s/\\n/\n/g;
-		my $question = $tl->Label(
-				-text	=> $text,
-				-font	=> $qfont,
-		)->pack(
-				-fill	=>'both',
-				-expand	=>1
-		);
+	my $text;
+	($text=$jdata{$Cat[$c]}[$f])=~ s/\\n/\n/g;
+	my $question = $tl->Label(
+			-text	=> $text,
+			-font	=> $qfont,
+	)->pack(
+			-fill	=>'both',
+			-expand	=>1
+	);
 
-		$tl->focusForce if ($force);
+	$ser_inhibit=0;
+	$tl->fileevent(\*Client,'readable',[\&ser_answerQuest,$tl,$c,$f]) if($tty);
 
-		$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
+	$tl->focusForce if ($force);
+
+	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
 };
+
+sub ser_answerQuest {
+	my ($crap,$c,$f,$key)=@_;
+	if($ser_inhibit++){
+		print "Don't press now\n";
+#		return;
+	}
+	print "cb!\n";
+	my $key=<Client>;
+	$key=~s/\r\n$//;
+	&answerQuest($crap,$c,$f,$key);
+	print "cb done\n";
+};
+
 
 # User answered the Question.
 sub answerQuest{
 	my ($crap,$c,$f,$key)=@_;
-#	print "answered: $c $f $key\n";
+	print "answered: $c $f $key\n";
 	if($key eq "q"){
 		$crap->destroy;
 		$button[$c][$f]->focusForce if ($force);
@@ -245,3 +290,44 @@ sub moveCrsr{
 	return;
 };
 
+sub ser_reset{
+	print "Resetting...\n" if ($debug);
+	my $ok=0;
+	do {
+		print Client "R\r\n";
+		$ok=<Client>;
+		if ($ok eq "N\r\n"){
+#			my $tl = MainWindow->new->toplevel;
+#
+#			$tl->configure(-height => $height/4, -width => $width/4);
+#			$tl->resizable(0,0);
+#			$tl->packPropagate(0);	# Keep the size.
+#			$tl->overrideredirect(1) if($override);
+#
+#			my $tlabel = $tl->Label(
+#					-text	=> "ser_reset",
+#					-relief	=> 'ridge',
+#					-font	=> $tfont,
+#			) -> pack(-fill	=> 'x');
+#
+#			my $question = $tl->Label(
+#					-text	=> "Please release all Buttons",
+#					-font	=> $qfont,
+#			)->pack(
+#					-fill	=>'both',
+#					-expand	=>1
+#			);
+#			$tl->bind('<Key>',[\&ser_reset_retry,Ev('A')]);
+#			$crap->destroy;
+			print "Failed\n";scalar(<>); # XXX
+		}
+		print $ok;
+	} while ($ok ne "A\r\n");
+
+	print Client "A\r\n";
+	$ok=<Client>;
+	if ($ok ne "A\r\n"){
+		print "FATAL: ser_unit not correctly responding\n";
+		die;
+	};
+};

--- a/beopardy
+++ b/beopardy
@@ -22,6 +22,7 @@ my $override=0;					# Ignore windowmanager?
 my $force=0;					# move focus for kbd-mode?
 my $tty=0;						# use tty/serial input?
 my $splash=0;					# Display a splashscreen?
+my $soundd=0;					# Use Soundd-output?
 my $socket=0;					# tty emulated by tcp socket?
 my $geometry=0;					# How big should I be?
 my $readfile;					# Should I read from a file?
@@ -50,7 +51,7 @@ sub _ {
 };
 
 my %opt;
-getopts('doftsg:r:hwb', \%opt);
+getopts('ydoftsg:r:hwb', \%opt);
 
 # Possible screen sizes
 my %screen=( 320 => 200,
@@ -75,6 +76,7 @@ beopardy -options Gamefile Player1 Player2 ...
 -b		Beopardy splashscreen. Default for serial input.
 -r <file>	Read saved game from File.
 -w		Save game progress for reading with -r.
+-y		Contact soundd at localhost 32001
 -g <size>	geometry. Select window size.
 		0: fullscreen (default)
 EOF
@@ -93,6 +95,7 @@ $tty=1		if (defined $opt{t});
 $socket=1	if (defined $opt{s});
 $savefile=1	if (defined $opt{w});
 $splash=1	if (defined $opt{b});
+$soundd=1	if (defined $opt{y});
 
 if($opt{r}){ # Read savefile
 	if ( -f $opt{r} ){
@@ -148,6 +151,20 @@ if ($tty){
 	print "done.\n";
 	autoflush Client;
 };
+
+my $snd_save; # resume sound..
+if($soundd){
+		my $port = 32001;
+		my $proto = getprotobyname('tcp');
+		socket(Soundd, PF_INET, SOCK_STREAM, $proto)	|| die "socket: $!";
+
+		my $iaddr   = inet_aton("localhost");
+		my $paddr   = sockaddr_in($port, $iaddr);
+		$proto   = getprotobyname('tcp');
+		connect(Soundd, $paddr)							|| die "connect: $!";
+		autoflush Soundd
+};
+&snd_stop(0); # Just to make sure, and to install snd_eat.
 
 print "Reading questions....\n";
 my %jdata;
@@ -247,9 +264,9 @@ my @points;
 
 # Here starts the Tk part...
 #my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
-my $qfont=$tl->X11Font('-truetype-arial-medium-r-*-*-40-*-*-*-*-*-ascii-*');
+my $qfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-40-*-*-*-*-*-ascii-*');
 print "Question-Font:\n$qfont\n" if ($debug);
-#my $qsfont=$tl->X11Font('-truetype-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
+#my $qsfont=$tl->X11Font('-webfonts-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
 
 #my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
 my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-25-*-*-*-*-*-iso8859-1');
@@ -269,7 +286,8 @@ my $tlabel = $tl -> Label (
 
 $tl->eventAdd('<<quit>>'=>'<Button-3>');
 $tl->eventAdd('<<quit>>'=>'<Q>');
-$tl->bind('<<quit>>',sub{print "Done:\n",map {sprintf "%10s:%5d\n",$players[$_],$points[$_]} sort {$points[$b]<=>$points[$a]} (1..$#points);exit});
+$tl->bind('<<quit>>',sub{&snd_stop();print "Done:\n",map {sprintf "%10s:%5d\n",$players[$_],$points[$_]} sort {$points[$b]<=>$points[$a]} (1..$#points);exit});
+$tl->bind('<Z>',sub{&snd_zap()});
 
 # Game-Buttons.
 my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
@@ -558,20 +576,31 @@ sub selectQuest{
 
 # XXX Pixmap-Hack. *funfunfun*
 
-	my ($i,$fnam);
-	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img):(.*?)\]/){
-		$fnam=$2;
-		print "This is a $1 - $2\n";
-		if(!defined($imgcache{$fnam})){
-			$imgcache{$fnam} = $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
+	my ($typ,$fnam);
+	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img|snd):(.*?)\]/){
+		$typ=$1;$fnam=$2;
+		print "This is of $typ - \'$2\'\n";
+		if($typ eq "img"){
+			if(!defined($imgcache{$fnam})){
+				$imgcache{$fnam} = $tl->Pixmap($fnam,-file => "img/".$fnam.".xpm");
+			};
 		};
 	}
 
+	$snd_save=undef;
 	my $question;
 	if (defined($fnam) && defined($imgcache{$fnam})){
 		$question = $tl->Label(
 			-image	=> "$fnam",
 		);
+	}elsif(defined($fnam)&&($typ eq "snd")){
+		$question = $tl->Label(
+			-text	=> "listen...",
+			-font	=> $qfont,
+			-justify	=> "left",
+		);
+		&snd_play($fnam);
+		$snd_save=$fnam;
 	}else{
 		$question = $tl->Label(
 			-text	=> $jdata{$Cat[$c]}[$f],
@@ -591,10 +620,15 @@ sub selectQuest{
 	$tl->afterIdle(sub {&ser_en($tl,$c,$f) if ($tty);}); # fix Bug#2
 };
 
+my @cur_ser_answer=undef;
+
 sub ser_answerQuest {
 	my ($crap,$c,$f)=@_;
 
 	my $key=<Client>;
+
+	&snd_play("think",1);
+
 	$key=~s/\r?\n$//;
 
 	my $ich=$crap->Toplevel;
@@ -603,25 +637,30 @@ sub ser_answerQuest {
 	$ich->resizable(0,0);
 	$ich->geometry("-0-0");
 
+
 	my $ftl = $ich->Frame( -relief => 'ridge', -bd => 4)->pack;
-	$ftl->Label(
+	$cur_ser_answer[0]=$ftl->Label(
 			-text	=> $players[$key],
 			-font	=> $qfont,
 	)->pack(
 			-fill	=>'x',
 			-expand	=> 1,
 	);
+	
 	my $bframe=$ftl->Frame->pack(-fill=>'both',-expand=>1);
 
 	my $br=$bframe->Button(
 			-text		=> _('Richtig'),
-			-command	=> [\&answerQuest,$crap,$c,$f,$key],
+			-command	=> sub{
+							&answerQuest($crap,$c,$f,$key)
+							},
 	)->pack(-side	=>'left');
 	my $bf=$bframe->Button(
 			-text		=> _('Falsch'),
 			-command	=> sub{
 							$ich->destroy;
 							&answerQuest($crap,$c,$f,-$key);
+							&snd_resume;
 							$crap->focusForce if ($force);
 							&ser_en($crap,$c,$f)},
 	)->pack(-side	=>'left');
@@ -629,6 +668,8 @@ sub ser_answerQuest {
 			-text		=> _('Oops'),
 			-command	=> sub{$ich->destroy;
 							  &ser_reset;
+							  &snd_stop;
+							  &snd_resume;
 							  $crap->focusForce if ($force);
 							  &ser_en($crap,$c,$f)},
 	)->pack;
@@ -663,12 +704,42 @@ sub ser_dis{
 	$tl->fileevent(\*Client,'readable',[\&ser_noinp]);
 };
 
+sub snd_play{
+	return if (!$soundd);
+	my($sound,$what)=(shift,shift);
+	print Soundd "P $sound\r\n";
+	if($what){
+		$tl->fileevent(\*Soundd,'readable',[\&snd_color]); # DWIM!
+	}else{
+		$tl->fileevent(\*Soundd,'readable',[\&snd_eat]);
+	};
+};
+sub snd_stop{
+	return if (!$soundd);
+	print Soundd "Stop\r\n";
+	$tl->fileevent(\*Soundd,'readable',[\&snd_eat]);
+};
+sub snd_zap{
+	return if (!$soundd);
+	print Soundd "Z\r\n";
+	$tl->fileevent(\*Soundd,'readable',[\&snd_eat]);
+};
+
+sub snd_resume{
+	return if (!$soundd);
+	if($snd_save){
+		print Soundd "P $snd_save\r\n";
+	};
+	$tl->fileevent(\*Soundd,'readable',[\&snd_eat]);
+};
+
 # User answered the Question.
 sub answerQuest{
 	my ($crap,$c,$f,$key)=@_;
 	print "answered: $c $f $key\n";
 	my $sgn=1;
 	if($key eq "q"){
+		&snd_stop(0);
 		$crap->destroy;
 		&ser_dis if ($tty);  # "input nach 'q' auf frage" fix.
 		$button[$c][$f]->focusForce if ($force);
@@ -692,6 +763,7 @@ sub answerQuest{
 			$crap->destroy if ($sgn>0);
 			&ser_reset if ($tty);
 			$button[$c][$f]->focusForce if ($force && ($sgn>0));
+			&snd_stop(0);
 			return;
 		};
 	};
@@ -805,4 +877,20 @@ sub ser_eat {
 		$foo="Unexpected serial input:\n$foo\n";
 	};
 	${$ref}.=$foo;
+};
+
+#Silently eat anyting...
+sub snd_eat {
+	my $foo=scalar(<Soundd>);
+	print "got: ",$foo;
+};
+sub snd_color {
+	my $foo=scalar(<Soundd>);
+	print "Cgot: ",$foo;
+	if($foo=~/^E/){
+		$cur_ser_answer[0]->configure(
+			-background			=> "red",
+				);
+	};
+
 };

--- a/beopardy
+++ b/beopardy
@@ -285,10 +285,11 @@ print "Question-Font:\n$qfont\n" if ($debug);
 
 #my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
 #my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-45-*-*-*-*-*-iso8859-1');
-my $tfont=$tl->X11Font('-*-freesans-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
+my $tfont=$tl->X11Font('-*-freesans-medium-r-*-*-40-*-*-*-*-*-iso8859-*');
 print "Title-Font:\n$tfont\n" if($debug);
 
-my $sfont=$tl->X11Font('-*-freemono-medium-r-*-*-*-*-*-*-*-*-iso8859-*');
+#my $sfont=$tl->X11Font('-*-freemono-medium-r-*-*-10-*-*-*-*-*-iso8859-*');
+my $sfont=$tl->X11Font('-*-freesans-medium-r-*-*-20-*-*-*-*-*-iso8859-*');
 print "Small-Font:\n$sfont\n" if($debug);
 
 my $fixedfont=$tl->X11Font('-*-freemono-medium-r-*-*-*-*-*-*-*-*-iso8859-*');

--- a/beopardy
+++ b/beopardy
@@ -164,7 +164,7 @@ if ($tty){
 		print "connection from $name [", inet_ntoa($iaddr), "] at port $iport\n";
 	}else{
 		# Be sure to set device to -crtscts 19200
-		open(Client,"+>/dev/ttyS0") || die "open: $!";
+		open(Client,"+>/dev/ttyUSB0") || die "open: $!";
 		use IO::Stty;
 #		IO::Stty::stty(\*Client,"-crtscts");
 		IO::Stty::stty(\*Client,"19200");

--- a/beopardy
+++ b/beopardy
@@ -6,40 +6,40 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.2 2000/12/23 13:01:19 sec Exp sec $;
+	q$Id: beopardy,v 1.3 2000/12/25 17:57:09 sec Exp sec $;
 
-my $ser_err=0;
 use strict;
 use Tk;
-#use Tk::Font;
 use Tk::X11Font;
 use Tk::Dialog;
 use Socket;
 use FileHandle;
 use Getopt::Std;
 
-# Defaults
+# Global options. Set via getopt.
 my $debug=0;
 my $override=0;					# Ignore windowmanager?
 my $force=0;					# move focus for kbd-mode?
 my $tty=0;						# use tty/serial input?
 my $socket=0;					# tty emulated by tcp socket?
 my $geometry=0;					# How big should I be?
-my %opt;
 
+my %opt;
 getopts('doftsg:h', \%opt);
 
+# Possible screen sizes
 my %screen=( 320 => 200,
 			 640 => 480,
 		     800 => 600, 
 			1024 => 786);
 
 my @beopardy = split(/ /,beopardy);
-my $qwidth=35;
 
 if (defined $opt{h}){
 	print <<EOF;
 This is Beopardy $beopardy[2] $beopardy[3].
+
+beopardy -options Gamefile Player1 Player2 ...
 
 -h	This help.
 -d	Debug mode. Print lots'o stuff.
@@ -77,13 +77,15 @@ if (defined $opt{g}){
 		($width,$height)=($opt{g},$screen{$opt{g}});
 	}else{
 		my @x = (sort {$a<=>$b} keys %screen);
-		if ((--$opt{g}<=$#x) && ($opt{g}>0 )){
+		if ((--$opt{g}<=$#x) && ($opt{g}>=0 )){
 			$width=$x[$opt{g}];
 			$height=$screen{$width};
 		};
 	};
 }
 
+my $q=5;						# Wieviele Fragen/Kategorie?
+my $qwidth=35;					# Width of a question.
 my $catwidth =10;				# Width of categories.
 my $namewidth=10;				# Width of player names
 
@@ -126,8 +128,9 @@ while (<J>){
 		$c=0;
 		next;
 	}
+	$_.=" ";
 	if (!s/\\n/\n/){
-		s/(.{20,35})\s+/$1\n/mg;
+		s/(.{10,$qwidth})\s+/$1\n/mg;
 	};
 	$jdata{$nam}[++$c]=$_;
 };
@@ -136,6 +139,45 @@ printf "%-20s:%2d\n",$nam,$c if ($debug);
 
 print "Totalling ",(scalar keys %jdata)," categories.\n";
 
+sub read_game{
+	my @Cat;			# Namen der Kategorien
+	my $q=shift;		# Wieviele Fragen/Kategorie?
+	my $gamefile=shift(@ARGV)||"Test.jg";
+	$gamefile .= ".jg" if ( -f $gamefile.".jg" );
+	$gamefile =~ /^([^.]+)(.jg)?/;
+	my $title=$1;		# Titel des Spielfelds.
+
+	print "\nReading game '$title' ...\n";
+	open(G,"<$gamefile") || die;
+	while (<G>){
+		chomp;
+		next if (/^\s*(#|$)/);
+		push @Cat,$_;
+	};
+	close(G);
+
+	my $p=0;
+	for (@Cat){
+		printf "%-20s:%2d\n",$_,$#{$jdata{$_}} if ($debug);
+		if ($#{$jdata{$_}} < $q){
+			print "ERROR: not enough questions in \"$_\"\n";
+			$p++;
+		};
+		if ($#{$jdata{$_}} > $q){
+			print "WARN : too many questions in \"$_\"\n";
+#			$p++;
+		};
+	};
+	if ($p){
+		print "Hit enter to continue...\n";
+		$p=<>;
+	};
+	return $title,@Cat;
+};
+
+# Titel und Fragen
+my ($title,@Cat)=&read_game($q);
+
 my @players;
 if ($#ARGV>0){
 	@players=@ARGV;
@@ -143,41 +185,16 @@ if ($#ARGV>0){
 	@players=qw(Foo Bar Baz);
 };
 
+my @colors=qw(darkred darkgreen darkblue);
+
 unshift @players,"Nobody";
-my @points=(0)x($#players+2);
-
-my @Cat;
-my $gamefile=shift||"Test.jg";
-$gamefile .= ".jg" if ( -f $gamefile.".jg" );
-$gamefile =~ /^([^.]+)(.jg)?/;
-my $title=$1;		# Titel des Spielfelds.
-my $q=5;			# Wieviele Fragen/Kategorie?
-
-print "\nReading game '$title' ...\n";
-open(G,"<$gamefile") || die;
-while (<G>){
-	chomp;
-	next if (/^\s*(#|$)/);
-	push @Cat,$_;
-};
-close(G);
-
-for (@Cat){
-	printf "%-20s:%2d\n",$_,$#{$jdata{$_}};
-	if ($#{$jdata{$_}} < $q){
-		print "ERROR: not enough questions in \"$_\"\n";
-	};
-	if ($#{$jdata{$_}} > $q){
-		print "WARN : too many questions in \"$_\"\n";
-	};
-};
-print "\n";
+my @points=(0)x($#players+1);
 
 # Here starts the Tk part...
-my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--25-*-*-*-*-*-iso8859-1');
+my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
 print "Question-Font:\n$qfont\n" if ($debug);
 
-my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--20-*-*-*-*-*-iso8859-1');
+my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
 print "Title-Font:\n$tfont\n" if($debug);
 
 $tl->configure(-height => $height, -width => $width);
@@ -195,11 +212,6 @@ my $tlabel = $tl -> Label (
 $tl->eventAdd('<<quit>>'=>'<Button-3>');
 $tl->eventAdd('<<quit>>'=>'<q>');
 $tl->bind('<<quit>>',sub{print "Done:\n",map {sprintf "%10s:%5d\n",$players[$_],$points[$_]} sort {$points[$b]<=>$points[$a]} (1..$#points);exit});
-
-sub selectQuest;
-sub answerQuest;
-sub moveCrsr;
-sub ser_reset;
 
 # Game-Buttons.
 my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
@@ -222,6 +234,7 @@ for my $cat (0..$#Cat){
 		$button[$cat][$q] = $frame[$cat]->Button(
 				-text		=> "${q}00",
 				-command	=> [\&selectQuest,$tl,$cat,$q],
+				-font		=> $tfont,
 		)->pack( -fill => 'both', -expand => 1);
 		$button[$cat][$q]->bind('<h>',[\&moveCrsr,$cat-1,$q  ]);
 		$button[$cat][$q]->bind('<j>',[\&moveCrsr,$cat  ,$q+1]);
@@ -229,8 +242,8 @@ for my $cat (0..$#Cat){
 		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
 	};
 };
-#$button[0][1]->focusForce if ($force);
 $button[0][1]->focus;
+#$button[0][1]->focusForce if ($force);
 
 # Scoreboard.
 my $sframe=$tl->Frame->pack(-side=>'top',-fill=>'x');
@@ -267,24 +280,21 @@ print "\nGame start.\n\n";
 
 if($tty){
 	my $dlg=$tl->Toplevel;
-	$dlg->Label(
+	$dlg->Button(
 			-text	=> "Start",
 			-font	=> $qfont,
+			-width	=> 30,
+			-height	=> 10,
+			-command	=> sub { $dlg->destroy;&ser_reset;$button[0][1]->focusForce if ($force)},
 	)->pack(
 			-fill	=>'x',
 			-expand	=>1,
 	);
-	my $bframe=$dlg->Frame->pack(-fill=>'both',-expand=>1);
-	$bframe->Button(
-			-text		=> 'Go ahead',
-			-command	=> sub { $dlg->destroy;&ser_reset}
-	)->pack(-side	=>'left')->focusForce;
 	$dlg->raise;
 	$dlg->grab;
+	$dlg->focusForce;
 	$tl->lower($dlg);
 };
-
-#&ser_reset if($tty);
 
 # Make the 'resetting' window...
 my $reset=$tl->Toplevel;
@@ -292,7 +302,7 @@ $reset->overrideredirect(1);
 $reset->resizable(0,0);
 $reset->geometry("-0+0");
 $reset->withdraw;
-$reset->Label(-text=>"resetting")->pack;
+$reset->Label(-text=>"resetting",-background=>"green")->pack;
 
 MainLoop;
 
@@ -300,8 +310,7 @@ MainLoop;
 
 sub selectQuest{
 	my ($otl,$c,$f)=@_;
-#	print "selected ",join(",",@_),"\n" if ($debug);
-	print "Q$f / \"$Cat[$c]\": $jdata{$Cat[$c]}[$f]\n";
+	print "Q$f / \"$Cat[$c]\":\n$jdata{$Cat[$c]}[$f]\n";
 
 	my $tl = $otl->Toplevel;
 	$tl->configure(-height => $height, -width => $width);
@@ -336,15 +345,21 @@ sub ser_answerQuest {
 	my $key=<Client>;
 	$key=~s/\r\n$//;
 
-	my $tl=$crap->Toplevel;
-	$tl->Label(
+	my $ich=$crap->Toplevel;
+
+	$ich->overrideredirect(1) if($override);
+	$ich->resizable(0,0);
+	$ich->geometry("-0-0");
+
+	my $ftl = $ich->Frame( -relief => 'ridge', -bd => 4)->pack;
+	$ftl->Label(
 			-text	=> $players[$key],
 			-font	=> $qfont,
 	)->pack(
 			-fill	=>'x',
 			-expand	=>1,
 	);
-	my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
+	my $bframe=$ftl->Frame->pack(-fill=>'both',-expand=>1);
 
 	my $br=$bframe->Button(
 			-text		=> 'Richtig',
@@ -353,20 +368,22 @@ sub ser_answerQuest {
 	my $bf=$bframe->Button(
 			-text		=> 'Falsch',
 			-command	=> sub{
-							$tl->destroy;
+							$ich->destroy;
 							&answerQuest($crap,$c,$f,-$key);
+							$crap->focusForce if ($force);
 							&ser_en($crap,$c,$f)},
 	)->pack(-side	=>'left');
 	my $bo=$bframe->Button(
 			-text		=> 'Oops',
-			-command	=> sub{$tl->destroy;
+			-command	=> sub{$ich->destroy;
 							  &ser_reset;
+							  $crap->focusForce if ($force);
 							  &ser_en($crap,$c,$f)},
 	)->pack;
-	$tl->bind('<q>',sub{$tl->destroy; &ser_reset; &ser_en($crap,$c,$f)});
-	$tl->bind('<o>',sub{$tl->destroy; &ser_reset; &ser_en($crap,$c,$f)});
-	$tl->bind('<r>',[\&answerQuest,$crap,$c,$f,$key]);
-	$tl->bind('<f>',sub{$tl->destroy;&answerQuest($crap,$c,$f,-$key);&ser_en($crap,$c,$f)});
+#	$ich->bind('<q>',sub{$ich->destroy; &ser_reset; &ser_en($crap,$c,$f)});
+#	$ich->bind('<o>',sub{$ich->destroy; &ser_reset; &ser_en($crap,$c,$f)});
+#	$ich->bind('<r>',[\&answerQuest,$crap,$c,$f,$key]);
+#	$ich->bind('<f>',sub{$ich->destroy;&answerQuest($crap,$c,$f,-$key);&ser_en($crap,$c,$f)});
 
 	$br->bind('<l>',sub{$bf->focus});
 	$bf->bind('<l>',sub{$bo->focus});
@@ -377,11 +394,10 @@ sub ser_answerQuest {
 
 	$br->focusForce if($force);
 
-	print "ser_answer done\n";
+#	print "ser_answer done\n";
 };
 
 sub ser_en{
-	print "Arg1: $_[0]\n";
 	$tl->fileevent(\*Client,'readable',[\&ser_answerQuest,@_]);
 };
 sub ser_dis{
@@ -413,11 +429,9 @@ sub answerQuest{
 		};
 		if ($key <= $#players){
 			&updPlayfield($c,$f,$key,$sgn);
-			if ($sgn>0){
-				$button[$c][$f]->focusForce if ($force);
-				$crap->destroy;
-			};
+			$crap->destroy if ($sgn>0);
 			&ser_reset if ($tty);
+			$button[$c][$f]->focusForce if ($force && ($sgn>0));
 			return;
 		};
 	};
@@ -430,15 +444,26 @@ sub updPlayfield {
 	$points[$key]+=$sgn*$f*100;
 	
 	push @{$pts[$c][$f]},$sgn*$key;
-#	my $pl=join("\n",map {($_<0?"-":" ").$players[abs]} @{$pts[$c][$f]});
-	my $pl=join("",map {($_<0?"-":"+").abs} @{$pts[$c][$f]});
+	my $pl=join("\n",map {($_<0?"-":" ").$players[abs]} @{$pts[$c][$f]});
+#	my $pl=join("",map {($_<0?"-":"+").abs} @{$pts[$c][$f]});
+	my $col;
+	$col=${pts[$c][$f]}[-1];
+	if($col<0){$col=0};
+	$col=$colors[$col];
+	print "$col<------------\n";
 	print ">$pl<\n";
+#	my $oheight=$button[$c][$f]->height;
 	$button[$c][$f]->configure(
 			-text				=> $pl,
 			-relief				=> "flat",
 			-foreground			=>'grey',
 			-activeforeground	=>'grey',
+			-height				=> 1,
+			-width				=> 1,
+			-background			=> $col,
 	);
+#	$button[$c][$f]->GeometryRequest(40,$oheight/2);
+	return $pl;
 }
 
 sub moveCrsr{
@@ -455,6 +480,7 @@ sub ser_reset{
 	print "Resetting...\n" if ($debug);
 	my $ok;
 	$reset->deiconify;
+	$reset->raise;
 	$reset->grab;
 	do {
 		&ser_dis;
@@ -471,11 +497,13 @@ sub ser_reset{
 	print "...done\n" if ($debug);
 	$reset->grabRelease;
 	$reset->withdraw;
+	$tl->focusForce;
 };
 
 sub ser_noinp{
 	&ser_fatal("ser_junk");
 	&ser_reset;
+#	$button[0][0]->focus;
 };
 
 
@@ -488,6 +516,7 @@ sub ser_fatal{
 			-textvar => \$fatal,
 			-buttons => [ "try again" ],
 			);
+	$answer->overrideredirect(1);
 	$answer->focusForce;
 	$answer->Show();
 };

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.4 2000/12/28 16:17:46 sec Exp sec $;
+	q$Id: beopardy,v 1.6 2001/07/30 01:16:29 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -23,9 +23,29 @@ my $force=0;					# move focus for kbd-mode?
 my $tty=0;						# use tty/serial input?
 my $socket=0;					# tty emulated by tcp socket?
 my $geometry=0;					# How big should I be?
+my $readfile;					# Should I read from a file?
+my $savefile=0;					# Should I save to a file?
+
+# L10n
+my %ln = (
+		"Richtig"			=> "right",
+		"Falsch"			=> "wrong",
+		"Oops"				=> "oops",
+		"ist etwas unruhig"	=> "seems a bit nervous",
+		"Knopf loesen"		=> "release your button",
+		);
+
+sub _ {
+	my $key=shift;
+	if (defined ($ln{$key})){
+		return $ln{$key};
+	}else{
+		return $key;
+	};
+};
 
 my %opt;
-getopts('doftsg:h', \%opt);
+getopts('doftsg:r:hw', \%opt);
 
 # Possible screen sizes
 my %screen=( 320 => 200,
@@ -41,18 +61,20 @@ This is Beopardy $beopardy[2] $beopardy[3].
 
 beopardy -options Gamefile Player1 Player2 ...
 
--h	This help.
--d	Debug mode. Print lots'o stuff.
--o	Override. Ignore Windowmanager. (fullscreen)
--f	Force keyboard focus.           (fullscreen)
--t	Tty input. Use when Buzzers are connected.
--s	Socket. Emulate Tty input via tcp socket (port 3333)
--g	geometry. Select window size.
-	0: fullscreen (default)
+-h		This help.
+-d		Debug mode. Print lots'o stuff.
+-o		Override. Ignore Windowmanager. (fullscreen)
+-f		Force keyboard focus.           (fullscreen)
+-t		Tty input. Use when Buzzers are connected.
+-s		Socket. Emulate Tty input via tcp socket (port 3333)
+-r <file>	Read saved game from File.
+-w		Save game progress for reading with -r.
+-g <size>	geometry. Select window size.
+		0: fullscreen (default)
 EOF
 	my $x=1;
 	foreach (sort {$a <=> $b } keys %screen){
-		printf "\t%1d: %4dx%4d\n",$x++,$_,$screen{$_};
+		printf "\t\t%1d: %4dx%4d\n",$x++,$_,$screen{$_};
 	}
 	print "";
 	exit(42);
@@ -63,6 +85,13 @@ $override=1	if (defined $opt{o});
 $force=1	if (defined $opt{f});
 $tty=1		if (defined $opt{t});
 $socket=1	if (defined $opt{s});
+$savefile=1	if (defined $opt{w});
+
+if($opt{r}){ # Read savefile
+	if ( -f $opt{r} ){
+		$readfile=$opt{r};
+	};
+};
 
 if ($socket){$tty=1};	# socket emulates tty.
 
@@ -103,7 +132,7 @@ if ($tty){
 		my $paddr = accept(Client,Server);
 		my($iport,$iaddr) = sockaddr_in($paddr);
 		my $name = gethostbyaddr($iaddr,AF_INET);
-		print "connection from $name [", inet_ntoa($iaddr), "] at port $iport";
+		print "connection from $name [", inet_ntoa($iaddr), "] at port $iport\n";
 	}else{
 		# Be sure to set device to -crtscts 19200
 		open(Client,"+>/dev/cuaa0") || die "open: $!";
@@ -139,6 +168,12 @@ printf "%-20s:%2d\n",$nam,$c if ($debug);
 
 print "Totalling ",(scalar keys %jdata)," categories.\n";
 
+sub logname{
+	my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time);
+	$year+=1900;$mon++;
+	return (sprintf "%04d%02d%02d.%02d%02d",$year,$mon,$mday,$hour,$min);
+}
+
 sub read_game{
 	my @Cat;			# Namen der Kategorien
 	my $q=shift;		# Wieviele Fragen/Kategorie?
@@ -172,6 +207,15 @@ sub read_game{
 		print "Hit enter to continue...\n";
 		$p=<>;
 	};
+	if($savefile){
+		my($ts)=logname();
+		open(SAV,">$gamefile.$ts");
+		select(SAV);$|=1;
+		select(STDOUT);
+	}else{
+		open(SAV,">-");
+	};
+
 	return $title,@Cat;
 };
 
@@ -185,16 +229,21 @@ if ($#ARGV>0){
 	@players=qw(Foo Bar Baz);
 };
 
-my @colors=qw(grey darkred darkgreen darkblue);
+print SAV "[ply] ",join("/",@players),"\n";
+
+my @colors=qw(darkgrey darkred darkgreen darkblue);
 
 unshift @players,"Nobody";
 my @points=(0)x($#players+1);
 
 # Here starts the Tk part...
-my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
+#my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--40-*-*-*-*-*-iso8859-1');
+my $qfont=$tl->X11Font('-truetype-arial-medium-r-*-*-40-*-*-*-*-*-ascii-*');
 print "Question-Font:\n$qfont\n" if ($debug);
+my $qsfont=$tl->X11Font('-truetype-arial-medium-r-*-*-35-*-*-*-*-*-ascii-*');
 
-my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
+#my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--30-*-*-*-*-*-iso8859-1');
+my $tfont=$tl->X11Font('-bitstream-*-medium-r-*-*-36-*-*-*-*-*-iso8859-1');
 print "Title-Font:\n$tfont\n" if($debug);
 
 $tl->configure(-height => $height, -width => $width);
@@ -210,7 +259,7 @@ my $tlabel = $tl -> Label (
 ) -> pack(-fill	=> 'x');
 
 $tl->eventAdd('<<quit>>'=>'<Button-3>');
-$tl->eventAdd('<<quit>>'=>'<q>');
+$tl->eventAdd('<<quit>>'=>'<Q>');
 $tl->bind('<<quit>>',sub{print "Done:\n",map {sprintf "%10s:%5d\n",$players[$_],$points[$_]} sort {$points[$b]<=>$points[$a]} (1..$#points);exit});
 
 # Game-Buttons.
@@ -240,6 +289,11 @@ for my $cat (0..$#Cat){
 		$button[$cat][$q]->bind('<j>',[\&moveCrsr,$cat  ,$q+1]);
 		$button[$cat][$q]->bind('<k>',[\&moveCrsr,$cat  ,$q-1]);
 		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
+# Fuer mh, der die VI-Keys nicht mag...
+		$button[$cat][$q]->bind('<Left>' ,[\&moveCrsr,$cat-1,$q  ]);
+		$button[$cat][$q]->bind('<Down>' ,[\&moveCrsr,$cat  ,$q+1]);
+		$button[$cat][$q]->bind('<Up>'   ,[\&moveCrsr,$cat  ,$q-1]);
+		$button[$cat][$q]->bind('<Right>',[\&moveCrsr,$cat+1,$q  ]);
 	};
 };
 $button[0][1]->focus;
@@ -277,6 +331,19 @@ for (1..$#players){
 };
 
 #print "Board done.\n";
+
+if(defined $readfile){
+	my($c,$f,$sgn,$ply);
+	print "Reading Savegame...\n";
+	open(RSAV,$readfile) || die "Savegame error: $!";
+	while(<RSAV>){
+		next if(! /^\[sav\]/);
+		(undef,$c,$f,$sgn,$ply)=split;
+		print "$c - $f - $sgn - $ply\n";
+		updPlayfield($c,$f,$ply,$sgn);
+	};
+	close(RSAV);
+};
 
 print "\nGame start.\n\n";
 
@@ -327,10 +394,28 @@ sub selectQuest{
 			-font	=> $tfont,
 	) -> pack(-fill	=> 'x');
 
-	my $question = $tl->Label(
+# XXX Pixmap-Hack. *funfunfun*
+
+	my ($i,$fnam);
+	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img):(.*?)\]/){
+		$fnam=$2;
+		print "This is a $1 - $2\n";
+		$i= $tl->Pixmap($fnam,-file => $fnam.".xpm");
+	}
+
+	my $question;
+	if (defined $i){
+		$question = $tl->Label(
+			-image	=> "$fnam",
+		);
+	}else{
+		$question = $tl->Label(
 			-text	=> $jdata{$Cat[$c]}[$f],
 			-font	=> $qfont,
-	)->pack(
+		);
+	};
+
+	$question->pack(
 			-fill	=>'both',
 			-expand	=>1
 	);
@@ -345,7 +430,7 @@ sub ser_answerQuest {
 	my ($crap,$c,$f)=@_;
 
 	my $key=<Client>;
-	$key=~s/\r\n$//;
+	$key=~s/\r?\n$//;
 
 	my $ich=$crap->Toplevel;
 
@@ -359,16 +444,16 @@ sub ser_answerQuest {
 			-font	=> $qfont,
 	)->pack(
 			-fill	=>'x',
-			-expand	=>1,
+			-expand	=> 1,
 	);
 	my $bframe=$ftl->Frame->pack(-fill=>'both',-expand=>1);
 
 	my $br=$bframe->Button(
-			-text		=> 'Richtig',
+			-text		=> _('Richtig'),
 			-command	=> [\&answerQuest,$crap,$c,$f,$key],
 	)->pack(-side	=>'left');
 	my $bf=$bframe->Button(
-			-text		=> 'Falsch',
+			-text		=> _('Falsch'),
 			-command	=> sub{
 							$ich->destroy;
 							&answerQuest($crap,$c,$f,-$key);
@@ -376,7 +461,7 @@ sub ser_answerQuest {
 							&ser_en($crap,$c,$f)},
 	)->pack(-side	=>'left');
 	my $bo=$bframe->Button(
-			-text		=> 'Oops',
+			-text		=> _('Oops'),
 			-command	=> sub{$ich->destroy;
 							  &ser_reset;
 							  $crap->focusForce if ($force);
@@ -393,6 +478,13 @@ sub ser_answerQuest {
 	$br->bind('<h>',sub{$bo->focus});
 	$bf->bind('<h>',sub{$br->focus});
 	$bo->bind('<h>',sub{$bf->focus});
+# mh ist auch hier faul :)
+	$br->bind('<Right>',sub{$bf->focus});
+	$bf->bind('<Right>',sub{$bo->focus});
+	$bo->bind('<Right>',sub{$br->focus});
+	$br->bind('<Left>' ,sub{$bo->focus});
+	$bf->bind('<Left>' ,sub{$br->focus});
+	$bo->bind('<Left>' ,sub{$bf->focus});
 
 	$br->focusForce if($force);
 
@@ -413,7 +505,7 @@ sub answerQuest{
 	my $sgn=1;
 	if($key eq "q"){
 		$crap->destroy;
-#&ser_dis;
+		&ser_dis if ($tty);  # "input nach 'q' auf frage" fix.
 		$button[$c][$f]->focusForce if ($force);
 		return;
 	};
@@ -444,6 +536,7 @@ sub answerQuest{
 sub updPlayfield {
 	my ($c,$f,$key,$sgn)=@_;
 	print $sgn<0?"bad":"good"," for ",$players[$key],"\n";
+	print SAV "[sav] $c $f $sgn $key\n";
 	$points[$key]+=$sgn*$f*100;
 	
 	push @{$pts[$c][$f]},$sgn*$key;
@@ -452,7 +545,7 @@ sub updPlayfield {
 	my $col=${pts[$c][$f]}[-1];
 	if($col<0){$col=0};
 	$col=$colors[$col];
-	print ">$pl<\n";
+#	print ">$pl<\n";
 #	my $oheight=$button[$c][$f]->height;
 	$button[$c][$f]->configure(
 			-text				=> $pl,
@@ -462,9 +555,10 @@ sub updPlayfield {
 			-height				=> 1,
 			-width				=> 1,
 			-background			=> $col,
+			-font				=> $qfont,
 	);
 #	$button[$c][$f]->GeometryRequest(40,$oheight/2);
-    print "Pts:\n",map {sprintf "%s:%d/",$players[$_],$points[$_]} (1..$#points);
+    print "Pts:",(map {sprintf "%s:%d/",$players[$_],$points[$_]} (1..$#points)),"\n";
 	return $pl;
 }
 
@@ -481,6 +575,8 @@ sub moveCrsr{
 sub ser_reset{
 	print "Resetting...\n" if ($debug);
 	my $ok;
+	my $quux= $tl->focusSave();
+
 	$reset->deiconify;
 	$reset->raise;
 	$reset->grab;
@@ -488,39 +584,45 @@ sub ser_reset{
 		&ser_dis;
 		print Client "R\r\n";
 		$ok=<Client>;
-		if ($ok ne "A\r\n"){
-			if ($ok =~ /(\d)\r\n/) {
-				&ser_fatal($players[$1].", bitte Knopf loesen.");
+		$ok=~s/\r?\n//;
+		if ($ok ne "A"){
+			if ($ok =~ /(\d)/) {
+				&ser_fatal($players[$1].", "._("Knopf loesen").".");
 			}else{
 				&ser_fatal("ser_reset got $ok");
 			};
 		};
-	}while($ok ne "A\r\n");
+	}while($ok ne "A");
 	print "...done\n" if ($debug);
 	$reset->grabRelease;
 	$reset->withdraw;
-	$tl->focusForce;
+#	$tl->focusForce if ($force);
+	&$quux;
 };
 
 sub ser_noinp{
-	&ser_fatal("ser_junk");
+	&ser_fatal("");
 	&ser_reset;
 #	$button[0][0]->focus;
 };
 
 
 sub ser_fatal{
-	my $fatal=(shift)."\n";
+	my $fatal=(shift);
+
+	my $quux= $tl->focusSave();
+#	print "froobel: ",$quux,"\n";
 
 	$tl->fileevent(\*Client,'readable',[\&ser_eat,\$fatal]);
 
-	my $answer = $tl->Dialog(-title => "ser_reset",
+	my $answer = $tl->Dialog(-title => "ser_junk",
 			-textvar => \$fatal,
 			-buttons => [ "try again" ],
 			);
 	$answer->overrideredirect(1);
 	$answer->focusForce;
 	$answer->Show();
+	&$quux;
 };
 
 # Eat anything you get.
@@ -528,6 +630,11 @@ sub ser_eat {
 	my $ref=shift;
 	my $foo=scalar(<Client>);
 	print "got: ",$foo;
-	chomp($foo);
+	$foo=~s/\r?\n//;
+	if($foo =~ /^\d+$/){
+		$foo = $players[$foo] ." ". _("ist etwas unruhig")."\n";
+	}else{
+		$foo="Unexpected serial input:\n$foo\n";
+	};
 	${$ref}.=$foo;
 };

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.6 2001/07/30 01:16:29 sec Exp sec $;
+	q$Id: beopardy,v 1.7 2001/08/08 20:42:57 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -422,8 +422,8 @@ sub selectQuest{
 
 	$tl->focusForce if ($force);
 
-	&ser_en($tl,$c,$f) if ($tty);
 	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
+	$tl->afterIdle(sub {&ser_en($tl,$c,$f) if ($tty);}); # fix Bug#2
 };
 
 sub ser_answerQuest {

--- a/beopardy
+++ b/beopardy
@@ -4,51 +4,115 @@
 
 # This code is under the BSD Licence
 # (c) by Stefan `Sec` Zehl <sec@42.org>
-# $Id: beopardy,v 1.1 2000/12/04 02:48:47 sec Exp sec $
 
+use constant beopardy =>
+	q$Id: beopardy,v 1.2 2000/12/23 13:01:19 sec Exp sec $;
+
+my $ser_err=0;
 use strict;
 use Tk;
-use Tk::Font;
+#use Tk::Font;
 use Tk::X11Font;
+use Tk::Dialog;
 use Socket;
 use FileHandle;
+use Getopt::Std;
 
-my $debug=1;
+# Defaults
+my $debug=0;
 my $override=0;					# Ignore windowmanager?
 my $force=0;					# move focus for kbd-mode?
-my $tty=1;						# tty/serial input active?
-my $ser=1;						# tty/serial chooser.
-my $socket=1;					# tty emulated by tcp socket?
+my $tty=0;						# use tty/serial input?
+my $socket=0;					# tty emulated by tcp socket?
+my $geometry=0;					# How big should I be?
+my %opt;
 
-my ($width,$height)=(640,480);	# Size of game field.
+getopts('doftsg:h', \%opt);
+
+my %screen=( 320 => 200,
+			 640 => 480,
+		     800 => 600, 
+			1024 => 786);
+
+my @beopardy = split(/ /,beopardy);
+my $qwidth=35;
+
+if (defined $opt{h}){
+	print <<EOF;
+This is Beopardy $beopardy[2] $beopardy[3].
+
+-h	This help.
+-d	Debug mode. Print lots'o stuff.
+-o	Override. Ignore Windowmanager. (fullscreen)
+-f	Force keyboard focus.           (fullscreen)
+-t	Tty input. Use when Buzzers are connected.
+-s	Socket. Emulate Tty input via tcp socket (port 3333)
+-g	geometry. Select window size.
+	0: fullscreen (default)
+EOF
+	my $x=1;
+	foreach (sort {$a <=> $b } keys %screen){
+		printf "\t%1d: %4dx%4d\n",$x++,$_,$screen{$_};
+	}
+	print "";
+	exit(42);
+}
+
+$debug=1	if (defined $opt{d});
+$override=1	if (defined $opt{o});
+$force=1	if (defined $opt{f});
+$tty=1		if (defined $opt{t});
+$socket=1	if (defined $opt{s});
+
+if ($socket){$tty=1};	# socket emulates tty.
+
+my $tl = MainWindow -> new -> toplevel;
+$tl->appname(beopardy);
+my ($width,$height)=($tl->screenwidth,$tl->screenheight);	# Size of game field.
+
+if (defined $opt{g}){
+	if ($opt{g} =~ /^(\d+)[x*](\d+)$/){
+		($width,$height)=($1,$2);
+	} elsif ( defined $screen{$opt{g}}){
+		($width,$height)=($opt{g},$screen{$opt{g}});
+	}else{
+		my @x = (sort {$a<=>$b} keys %screen);
+		if ((--$opt{g}<=$#x) && ($opt{g}>0 )){
+			$width=$x[$opt{g}];
+			$height=$screen{$width};
+		};
+	};
+}
+
 my $catwidth =10;				# Width of categories.
 my $namewidth=10;				# Width of player names
-my $ser_inhibit=0;				# Global 'no input on serial now'
 
 if ($tty){
-print "Opening tty\n";
-if(!$ser){
-my $port = 3333;
-my $proto = getprotobyname('tcp');
-socket(Server, PF_INET, SOCK_STREAM, $proto)        || die "socket: $!";
-setsockopt(Server, SOL_SOCKET, SO_REUSEADDR, pack("l", 1))   || die "setsockopt: $!";
-bind(Server, sockaddr_in($port, INADDR_ANY))        || die "bind: $!" ;
-listen(Server,SOMAXCONN)                            || die "listen: $ !";
-print "Connect to port $port...\n";
-my $paddr = accept(Client,Server);
-my($iport,$iaddr) = sockaddr_in($paddr);
-my $name = gethostbyaddr($iaddr,AF_INET);
-print "connection from $name [", inet_ntoa($iaddr), "] at port $iport";
-}else{
-	open(Client,"+>/dev/cuaa0") || die;
-};
-print "done.\n";
-autoflush Client;
+	print "Opening tty\n";
+	if($socket){
+		my $port = 3333;
+		my $proto = getprotobyname('tcp');
+		socket(Server, PF_INET, SOCK_STREAM, $proto)	|| die "socket: $!";
+		setsockopt(Server, SOL_SOCKET, SO_REUSEADDR, pack("l", 1))
+														|| die "setsockopt: $!";
+		bind(Server, sockaddr_in($port, INADDR_ANY))	|| die "bind: $!" ;
+		listen(Server,SOMAXCONN)						|| die "listen: $!";
+		print "Now connect to port $port...\n";
+		my $paddr = accept(Client,Server);
+		my($iport,$iaddr) = sockaddr_in($paddr);
+		my $name = gethostbyaddr($iaddr,AF_INET);
+		print "connection from $name [", inet_ntoa($iaddr), "] at port $iport";
+	}else{
+		# Be sure to set device to -crtscts 19200
+		open(Client,"+>/dev/cuaa0") || die "open: $!";
+	};
+	print "done.\n";
+	autoflush Client;
 };
 
 print "Reading questions....\n";
 my %jdata;
-open (J,"<Test.jd") || die;
+open (J,"<Jeopardy") || die;
 my ($nam,$c);
 while (<J>){
 	chomp;
@@ -62,20 +126,29 @@ while (<J>){
 		$c=0;
 		next;
 	}
+	if (!s/\\n/\n/){
+		s/(.{20,35})\s+/$1\n/mg;
+	};
 	$jdata{$nam}[++$c]=$_;
 };
 close(J);
 printf "%-20s:%2d\n",$nam,$c if ($debug);
+
 print "Totalling ",(scalar keys %jdata)," categories.\n";
 
-my @players=qw(Christoph Chris Nick);
-my @points=(0,0,0);
+my @players;
+if ($#ARGV>0){
+	@players=@ARGV;
+}else{
+	@players=qw(Foo Bar Baz);
+};
 
 unshift @players,"Nobody";
-unshift @points,0;
+my @points=(0)x($#players+2);
 
 my @Cat;
 my $gamefile=shift||"Test.jg";
+$gamefile .= ".jg" if ( -f $gamefile.".jg" );
 $gamefile =~ /^([^.]+)(.jg)?/;
 my $title=$1;		# Titel des Spielfelds.
 my $q=5;			# Wieviele Fragen/Kategorie?
@@ -100,15 +173,12 @@ for (@Cat){
 };
 print "\n";
 
-
 # Here starts the Tk part...
-my $tl = MainWindow -> new -> toplevel;
-
 my $qfont=$tl->X11Font('-*-new century schoolbook-medium-r-*--25-*-*-*-*-*-iso8859-1');
-print "Question-Font:\n$qfont\n";
+print "Question-Font:\n$qfont\n" if ($debug);
 
 my $tfont=$tl->X11Font('-*-helvetica-medium-r-*--20-*-*-*-*-*-iso8859-1');
-print "Title-Font:\n$tfont\n";
+print "Title-Font:\n$tfont\n" if($debug);
 
 $tl->configure(-height => $height, -width => $width);
 $tl->resizable(0,0);
@@ -131,12 +201,10 @@ sub answerQuest;
 sub moveCrsr;
 sub ser_reset;
 
-&ser_reset;
-
 # Game-Buttons.
 my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
 my @button;	# The TkButtons 
-my @pts;	# Who got the points from this question?
+my @pts;	# Who got points from this question?
 my @frame;  # The TkFrames, one per category.
 for my $cat (0..$#Cat){
 	$frame[$cat]=$bframe->Frame->pack(
@@ -146,14 +214,14 @@ for my $cat (0..$#Cat){
 	);
 
 	$button[$cat][0] = $frame[$cat]->Label(
-			-width => $catwidth,
-			-text => $Cat[$cat],
-	)->pack(-fill => 'both');
+			-width	=> $catwidth,
+			-text	=> $Cat[$cat],
+	)->pack(-fill	=> 'both');
 
 	for my $q (1..$q) {
 		$button[$cat][$q] = $frame[$cat]->Button(
 				-text		=> "${q}00",
-				-command	=> [\&selectQuest,$cat,$q],
+				-command	=> [\&selectQuest,$tl,$cat,$q],
 		)->pack( -fill => 'both', -expand => 1);
 		$button[$cat][$q]->bind('<h>',[\&moveCrsr,$cat-1,$q  ]);
 		$button[$cat][$q]->bind('<j>',[\&moveCrsr,$cat  ,$q+1]);
@@ -161,7 +229,8 @@ for my $cat (0..$#Cat){
 		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
 	};
 };
-$button[0][1]->focusForce if ($force);
+#$button[0][1]->focusForce if ($force);
+$button[0][1]->focus;
 
 # Scoreboard.
 my $sframe=$tl->Frame->pack(-side=>'top',-fill=>'x');
@@ -192,22 +261,54 @@ for (1..$#players){
 	)->pack(-fill=>'x');
 };
 
+#print "Board done.\n";
+
 print "\nGame start.\n\n";
+
+if($tty){
+	my $dlg=$tl->Toplevel;
+	$dlg->Label(
+			-text	=> "Start",
+			-font	=> $qfont,
+	)->pack(
+			-fill	=>'x',
+			-expand	=>1,
+	);
+	my $bframe=$dlg->Frame->pack(-fill=>'both',-expand=>1);
+	$bframe->Button(
+			-text		=> 'Go ahead',
+			-command	=> sub { $dlg->destroy;&ser_reset}
+	)->pack(-side	=>'left')->focusForce;
+	$dlg->raise;
+	$dlg->grab;
+	$tl->lower($dlg);
+};
+
+#&ser_reset if($tty);
+
+# Make the 'resetting' window...
+my $reset=$tl->Toplevel;
+$reset->overrideredirect(1);
+$reset->resizable(0,0);
+$reset->geometry("-0+0");
+$reset->withdraw;
+$reset->Label(-text=>"resetting")->pack;
+
 MainLoop;
 
 # We selected a question...
 
 sub selectQuest{
-	my ($c,$f)=@_;
+	my ($otl,$c,$f)=@_;
 #	print "selected ",join(",",@_),"\n" if ($debug);
 	print "Q$f / \"$Cat[$c]\": $jdata{$Cat[$c]}[$f]\n";
 
-	my $tl = MainWindow->new->toplevel;
-
+	my $tl = $otl->Toplevel;
 	$tl->configure(-height => $height, -width => $width);
 	$tl->resizable(0,0);
 	$tl->packPropagate(0);	# Keep the size.
 	$tl->overrideredirect(1) if($override);
+	$tl->grab;
 
 	my $tlabel = $tl->Label(
 			-text	=> $Cat[$c],
@@ -215,70 +316,130 @@ sub selectQuest{
 			-font	=> $tfont,
 	) -> pack(-fill	=> 'x');
 
-	my $text;
-	($text=$jdata{$Cat[$c]}[$f])=~ s/\\n/\n/g;
 	my $question = $tl->Label(
-			-text	=> $text,
+			-text	=> $jdata{$Cat[$c]}[$f],
 			-font	=> $qfont,
 	)->pack(
 			-fill	=>'both',
 			-expand	=>1
 	);
 
-	$ser_inhibit=0;
-	$tl->fileevent(\*Client,'readable',[\&ser_answerQuest,$tl,$c,$f]) if($tty);
-
 	$tl->focusForce if ($force);
 
+	&ser_en($tl,$c,$f) if ($tty);
 	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
 };
 
 sub ser_answerQuest {
-	my ($crap,$c,$f,$key)=@_;
-	if($ser_inhibit++){
-		print "Don't press now\n";
-#		return;
-	}
-	print "cb!\n";
+	my ($crap,$c,$f)=@_;
+
 	my $key=<Client>;
 	$key=~s/\r\n$//;
-	&answerQuest($crap,$c,$f,$key);
-	print "cb done\n";
+
+	my $tl=$crap->Toplevel;
+	$tl->Label(
+			-text	=> $players[$key],
+			-font	=> $qfont,
+	)->pack(
+			-fill	=>'x',
+			-expand	=>1,
+	);
+	my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
+
+	my $br=$bframe->Button(
+			-text		=> 'Richtig',
+			-command	=> [\&answerQuest,$crap,$c,$f,$key],
+	)->pack(-side	=>'left');
+	my $bf=$bframe->Button(
+			-text		=> 'Falsch',
+			-command	=> sub{
+							$tl->destroy;
+							&answerQuest($crap,$c,$f,-$key);
+							&ser_en($crap,$c,$f)},
+	)->pack(-side	=>'left');
+	my $bo=$bframe->Button(
+			-text		=> 'Oops',
+			-command	=> sub{$tl->destroy;
+							  &ser_reset;
+							  &ser_en($crap,$c,$f)},
+	)->pack;
+	$tl->bind('<q>',sub{$tl->destroy; &ser_reset; &ser_en($crap,$c,$f)});
+	$tl->bind('<o>',sub{$tl->destroy; &ser_reset; &ser_en($crap,$c,$f)});
+	$tl->bind('<r>',[\&answerQuest,$crap,$c,$f,$key]);
+	$tl->bind('<f>',sub{$tl->destroy;&answerQuest($crap,$c,$f,-$key);&ser_en($crap,$c,$f)});
+
+	$br->bind('<l>',sub{$bf->focus});
+	$bf->bind('<l>',sub{$bo->focus});
+	$bo->bind('<l>',sub{$br->focus});
+	$br->bind('<h>',sub{$bo->focus});
+	$bf->bind('<h>',sub{$br->focus});
+	$bo->bind('<h>',sub{$bf->focus});
+
+	$br->focusForce if($force);
+
+	print "ser_answer done\n";
 };
 
+sub ser_en{
+	print "Arg1: $_[0]\n";
+	$tl->fileevent(\*Client,'readable',[\&ser_answerQuest,@_]);
+};
+sub ser_dis{
+	$tl->fileevent(\*Client,'readable',[\&ser_noinp]);
+};
 
 # User answered the Question.
 sub answerQuest{
 	my ($crap,$c,$f,$key)=@_;
 	print "answered: $c $f $key\n";
+	my $sgn=1;
 	if($key eq "q"){
 		$crap->destroy;
 		$button[$c][$f]->focusForce if ($force);
 		return;
 	};
+	my $pos;
+	$key=-$pos if (($pos=index('0!"#$%&/()',$key))>0);
+	$key=-3  if($key eq '§');
 	$key="0" if($key eq "`"); # Be nice on ami-kbd
-	if($key=~/^\d$/){
-		if (($key <= $#players)&&($key>=0)){
-				print "good for ",$players[$key],"\n";
-				$points[$key]+=$f*100;
-				if(defined $pts[$c][$f]){
-					$points[$pts[$c][$f]]-=$f*100;
-					print "EDIT: $players[$pts[$c][$f]] lost answer\n";
-				};
-				$crap->destroy;
-				$button[$c][$f]->configure(
-						-text				=> $players[$key],
-						-relief				=> "flat",
-						-foreground			=>'grey',
-						-activeforeground	=>'grey',
-				);
-				$pts[$c][$f]=$key;
+	$key="0" if($key eq "^"); # Be nice on german-kbd
+
+	print "->$key\n" if ($debug);
+
+	if($key=~/^-?\d$/){
+		if ($key<0) {
+			$sgn=-$sgn;
+			$key=-$key;
+		};
+		if ($key <= $#players){
+			&updPlayfield($c,$f,$key,$sgn);
+			if ($sgn>0){
 				$button[$c][$f]->focusForce if ($force);
-				return;
+				$crap->destroy;
+			};
+			&ser_reset if ($tty);
+			return;
 		};
 	};
 	print "I don't like this key ($key)...\n" if($debug);
 };
+
+sub updPlayfield {
+	my ($c,$f,$key,$sgn)=@_;
+	print $sgn<0?"bad":"good"," for ",$players[$key],"\n";
+	$points[$key]+=$sgn*$f*100;
+	
+	push @{$pts[$c][$f]},$sgn*$key;
+#	my $pl=join("\n",map {($_<0?"-":" ").$players[abs]} @{$pts[$c][$f]});
+	my $pl=join("",map {($_<0?"-":"+").abs} @{$pts[$c][$f]});
+	print ">$pl<\n";
+	$button[$c][$f]->configure(
+			-text				=> $pl,
+			-relief				=> "flat",
+			-foreground			=>'grey',
+			-activeforeground	=>'grey',
+	);
+}
 
 sub moveCrsr{
 	my ($widget,$c,$f)=@_;
@@ -292,42 +453,50 @@ sub moveCrsr{
 
 sub ser_reset{
 	print "Resetting...\n" if ($debug);
-	my $ok=0;
+	my $ok;
+	$reset->deiconify;
+	$reset->grab;
 	do {
+		&ser_dis;
 		print Client "R\r\n";
 		$ok=<Client>;
-		if ($ok eq "N\r\n"){
-#			my $tl = MainWindow->new->toplevel;
-#
-#			$tl->configure(-height => $height/4, -width => $width/4);
-#			$tl->resizable(0,0);
-#			$tl->packPropagate(0);	# Keep the size.
-#			$tl->overrideredirect(1) if($override);
-#
-#			my $tlabel = $tl->Label(
-#					-text	=> "ser_reset",
-#					-relief	=> 'ridge',
-#					-font	=> $tfont,
-#			) -> pack(-fill	=> 'x');
-#
-#			my $question = $tl->Label(
-#					-text	=> "Please release all Buttons",
-#					-font	=> $qfont,
-#			)->pack(
-#					-fill	=>'both',
-#					-expand	=>1
-#			);
-#			$tl->bind('<Key>',[\&ser_reset_retry,Ev('A')]);
-#			$crap->destroy;
-			print "Failed\n";scalar(<>); # XXX
-		}
-		print $ok;
-	} while ($ok ne "A\r\n");
+		if ($ok ne "A\r\n"){
+			if ($ok =~ /(\d)\r\n/) {
+				&ser_fatal($players[$1].", bitte Knopf loesen.");
+			}else{
+				&ser_fatal("ser_reset got $ok");
+			};
+		};
+	}while($ok ne "A\r\n");
+	print "...done\n" if ($debug);
+	$reset->grabRelease;
+	$reset->withdraw;
+};
 
-	print Client "A\r\n";
-	$ok=<Client>;
-	if ($ok ne "A\r\n"){
-		print "FATAL: ser_unit not correctly responding\n";
-		die;
-	};
+sub ser_noinp{
+	&ser_fatal("ser_junk");
+	&ser_reset;
+};
+
+
+sub ser_fatal{
+	my $fatal=(shift)."\n";
+
+	$tl->fileevent(\*Client,'readable',[\&ser_eat,\$fatal]);
+
+	my $answer = $tl->Dialog(-title => "ser_reset",
+			-textvar => \$fatal,
+			-buttons => [ "try again" ],
+			);
+	$answer->focusForce;
+	$answer->Show();
+};
+
+# Eat anything you get.
+sub ser_eat {
+	my $ref=shift;
+	my $foo=scalar(<Client>);
+	print "got: ",$foo;
+	chomp($foo);
+	${$ref}.=$foo;
 };

--- a/beopardy
+++ b/beopardy
@@ -6,7 +6,7 @@
 # (c) by Stefan `Sec` Zehl <sec@42.org>
 
 use constant beopardy =>
-	q$Id: beopardy,v 1.12 2003/12/31 23:28:30 sec Exp sec $;
+	q$Id: beopardy,v 1.13 2004/12/25 13:11:47 sec Exp sec $;
 
 use strict;
 use Tk;
@@ -302,6 +302,7 @@ $tl->bind('<Z>',sub{&snd_zap()});
 my $bframe=$tl->Frame->pack(-fill=>'both',-expand=>1);
 my @button;	# The TkButtons 
 my @pts;	# Who got points from this question?
+my @log;	# Pointslog
 my @frame;  # The TkFrames, one per category.
 my @mframe; # A frame per button to avoid stupid resizing.
 for my $cat (0..$#Cat){
@@ -334,7 +335,8 @@ for my $cat (0..$#Cat){
 		$button[$cat][$q]->bind('<j>',[\&moveCrsr,$cat  ,$q+1]);
 		$button[$cat][$q]->bind('<k>',[\&moveCrsr,$cat  ,$q-1]);
 		$button[$cat][$q]->bind('<l>',[\&moveCrsr,$cat+1,$q  ]);
-#		$button[$cat][$q]->bind('<e>',[\&edit_pts,$cat  ,$q  ]);
+		$button[$cat][$q]->bind('<e>',[\&edit_pts,$cat  ,$q  ]);
+		$button[$cat][$q]->bind('<f>',[\&finish]);
 # Fuer mh, der die VI-Keys nicht mag...
 		$button[$cat][$q]->bind('<Left>' ,[\&moveCrsr,$cat-1,$q  ]);
 		$button[$cat][$q]->bind('<Down>' ,[\&moveCrsr,$cat  ,$q+1]);
@@ -346,6 +348,9 @@ $button[0][1]->focus;
 #$button[0][1]->focusForce if ($force);
 
 @points=(0)x(4);
+if($#players>3){
+	@points=(0)x($#players+1);
+};
 sub scoreboard(){ # Scoreboard.
 my $sframe=$tl->Frame->pack(-side=>'top',-fill=>'x');
 my @pborder;
@@ -394,7 +399,7 @@ if(defined $readfile){
 #			unshift @players,"Nobody";
 			next;
 		};
-		if(/^\[DBL\] (\d+)/){
+		if(/^\[DBL\] (-?\d+)/){
 			$global_dbl_amt=$1;
 			$global_is_dbl=1;
 		};
@@ -607,7 +612,7 @@ sub selectQuest{
 
 	my ($typ,$fnam);
 	$typ="";
-	print $jdata{$Cat[$c]}[$f]," <-\n";
+	print $jdata{$Cat[$c]}[$f]," <-\n" if($debug);
 	if ($jdata{$Cat[$c]}[$f] =~ /^\[(img|snd):(.*?)\]\s*/){
 #		print "JA\n";
 		$typ=$1;$fnam=$2;
@@ -659,8 +664,6 @@ sub selectQuest{
 	$tl->focusForce if ($force);
 
 	$tl->bind('<Key>',[\&answerQuest,$c,$f,Ev('A')]);
-
-	print("Hello $global_is_dbl \n");
 
 	$tl->waitVisibility; # To fix stacking order
 	if($global_is_dbl){
@@ -838,6 +841,7 @@ sub updPlayfield {
 	print $sgn<0?"bad":"good"," for ",$players[$key],"\n";
 	print SAV "[DBL] $global_dbl_amt\n" if ($global_is_dbl);
 	print SAV "[sav] $c $f $sgn $key\n";
+	push @{$log[$c][$f]},[$sgn,$key,$global_is_dbl?$global_dbl_amt:0];
 	if($global_is_dbl){
 		$points[$key]+=$sgn*$global_dbl_amt;
 		$global_is_dbl=0;
@@ -848,27 +852,8 @@ sub updPlayfield {
 		$global_dbl_ply=$key;
 	}; # cache player who has the tag....
 	
-	push @{$pts[$c][$f]},$sgn*$key;
-	my $pl=join("\n",map {($_<0?"-":" ").$players[abs]} @{$pts[$c][$f]});
-#	my $pl=join("",map {($_<0?"-":"+").abs} @{$pts[$c][$f]});
-	my $col=${pts[$c][$f]}[-1];
-	if($col<0){$col=0};
-	$col=$colors[$col];
-#	print ">$pl<\n";
-#	my $oheight=$button[$c][$f]->height; print "$c/$f: $oheight\n";
-	$button[$c][$f]->configure(
-			-text				=> $pl,
-			-relief				=> "flat",
-			-foreground			=>'grey',
-			-activeforeground	=>'grey',
-			-height				=> 0,
-			-width				=> 0,
-			-background			=> $col,
-			-font				=> "fixed",
-	);
-#	$button[$c][$f]->GeometryRequest(40,$oheight/2);
+	updBox($button[$c][$f],$c,$f);
     print "Pts:",(map {sprintf "%s:%d/",$players[$_],$points[$_]} (1..$#points)),"\n";
-	return $pl;
 }
 
 sub moveCrsr{
@@ -1050,3 +1035,204 @@ sub dblplychg{
 			-background	=> $colors[$global_dbl_ply]);
 };
 
+sub edit_pts {
+	my($widget,$c,$f)=@_;
+	print "Edit!\n";
+
+	my $ichtl=$widget->Toplevel;
+	$ichtl->overrideredirect(1) if($override);
+	$ichtl->resizable(0,0);
+#	$ichtl->geometry("+100+100");
+
+	my $ich = $ichtl->Frame( -relief => 'ridge', -bd => 4)->pack;
+	$ich->Label(
+			-text	=> "$Cat[$c] ${f}00",
+			-font	=> $tfont,
+	)->pack(
+			-fill	=>'x',
+			-expand	=> 1,
+	);
+
+	push @{$log[$c][$f]},[0,0,0];
+
+	my @ebtn;
+	for (0..$#{$log[$c][$f]}){
+		my ($sgn,$ply,$dbl)=@{$log[$c][$f][$_]};
+#		print "$sgn $ply $dbl\n";
+		$ebtn[$_]=$ich->Button(
+				-text		=> "$players[$ply] $sgn [$dbl]",
+				-command	=> sub{ ; },
+				-background	=> $colors[$ply],
+				-foreground	=> "white",
+			)->pack(-fill	=>'x', -expand => 1);
+	};
+
+	my $br=$ich->Button(
+			-text		=> 'Use: 0-4 +-d and Left-Right.',
+			-command	=> sub{
+							$ichtl->destroy;
+							updBox($widget,$c,$f);
+							$widget->focusForce if ($force);
+							},
+	)->pack(-fill	=>'x', -expand => 1);
+
+	for (0..$#ebtn){
+		my $cur=$ebtn[$_];
+		$cur->bind('<d>' ,[ \&adjscore, $c,$f,$_, 0,0]);
+		$cur->bind('<plus>' ,[ \&adjscore, $c,$f,$_, 0,+1]);
+		$cur->bind('<minus>' ,[ \&adjscore, $c,$f,$_, 0,-1]);
+		$cur->bind('<KeyPress-0>' ,[ \&adjscore, $c,$f,$_, 1,0]);
+		$cur->bind('<KeyPress-1>' ,[ \&adjscore, $c,$f,$_, 1,1]);
+		$cur->bind('<KeyPress-2>' ,[ \&adjscore, $c,$f,$_, 1,2]);
+		$cur->bind('<KeyPress-3>' ,[ \&adjscore, $c,$f,$_, 1,3]);
+		$cur->bind('<KeyPress-4>' ,[ \&adjscore, $c,$f,$_, 1,4]) if($#players==4);
+		$cur->bind('<Left>'  ,[ \&adjscore, $c,$f,$_, 2,-50]);
+		$cur->bind('<Right>' ,[ \&adjscore, $c,$f,$_, 2,+50]);
+	};
+
+	push @ebtn,$br;
+
+	for (0..$#ebtn){
+		my $prev=$ebtn[$_-1];
+		my $next=$ebtn[$_+1];
+		$ebtn[$_]->bind('<k>' ,sub{$prev->focus}) unless $_ == 0;
+		$ebtn[$_]->bind('<Up>' ,sub{$prev->focus}) unless $_ == 0;
+		$ebtn[$_]->bind('<Down>' ,sub{$next->focus}) unless $_ == $#ebtn;
+		$ebtn[$_]->bind('<j>' ,sub{$next->focus}) unless $_ == $#ebtn;
+		$ebtn[$_]->bind('<q>' ,sub{$ichtl->destroy;
+							updBox($widget,$c,$f);
+							$widget->focusForce if ($force);
+							} 
+				);
+	};
+
+	$br->focus;
+	$br->focusForce if($force);
+
+	$ichtl->idletasks;
+	$ichtl->geometry(sprintf "+%d+%d",($ich->screenwidth-$ich->width)/2,($ich->screenheight-$ich->height)/2);
+
+};
+
+sub adjscore{
+	my ($wid,$c,$f,$nr,$adjw,$adjto)=@_;
+#	print "adj $adjw $adjto\n";
+	my $pts=$f*100;
+	$pts= $log[$c][$f][$nr][2] if($log[$c][$f][$nr][2]);
+	$pts*=$log[$c][$f][$nr][0];
+	$points[$log[$c][$f][$nr][1]]-=$pts;
+
+	print SAV "<edit>\n";
+	print SAV "[DBL] $log[$c][$f][$nr][2]\n" if($log[$c][$f][$nr][2]);
+	print SAV "[sav] $c $f ".(-$log[$c][$f][$nr][0])." ".($log[$c][$f][$nr][1])."\n";
+
+	if($adjw==2){
+	$log[$c][$f][$nr][$adjw]+=$adjto;
+	}else{
+	$log[$c][$f][$nr][$adjw]=$adjto;
+	};
+
+	$pts=$f*100;
+	$pts= $log[$c][$f][$nr][2] if($log[$c][$f][$nr][2]);
+	$pts*=$log[$c][$f][$nr][0];
+	$points[$log[$c][$f][$nr][1]]+=$pts;
+
+	print SAV "[DBL] $log[$c][$f][$nr][2]\n" if($log[$c][$f][$nr][2]);
+	print SAV "[sav] $c $f ".($log[$c][$f][$nr][0])." ".($log[$c][$f][$nr][1])."\n";
+
+	$wid->configure(-text=>"$players[$log[$c][$f][$nr][1]] $log[$c][$f][$nr][0] [$log[$c][$f][$nr][2]]",
+			-background	=> $colors[$log[$c][$f][$nr][1]]
+			);
+};
+
+sub updBox{
+	my($wid,$c,$f)=@_;
+
+	my $pl="";
+	my $col=$colors[0];
+
+	my @lst;
+	@lst=@{$log[$c][$f][$#{$log[$c][$f]}]};
+	if ($lst[0]==0 && $lst[1] ==0){
+		pop@{$log[$c][$f]};
+	};
+
+	for(@{$log[$c][$f]}){
+		my ($sgn,$ply,$dbl)=@{$_};
+		next if($sgn==0);
+		$pl.="\n"if($pl);
+		$pl.=($sgn==1?"+":"-").$players[$ply].($dbl?"[d]":"");
+		if($sgn>0 && $ply>0){
+			$col=$colors[$ply];
+		}
+	}
+
+	$wid->configure(
+			-text				=> $pl,
+			-relief				=> "flat",
+			-foreground			=>'grey',
+			-activeforeground	=>'grey',
+			-height				=> 0,
+			-width				=> 0,
+			-background			=> $col,
+			-font				=> "fixed",
+	);
+}
+
+sub finish{
+	my $dlg=$tl->Toplevel;
+	my $i;
+	my $rframe;
+	my @win=sort {$points[$b]<=>$points[$a]} (1..$#points);
+	unshift @win,"0";
+
+#	$dlg->configure(-height => $height, -width => $width);
+#	$dlg->resizable(0,0);
+#	$dlg->packPropagate(0);	# Keep the size.
+	$dlg->overrideredirect(1);
+	my $q=$dlg->Label(qw/-relief raised -width 80/)->pack;
+
+	snd_play("end");
+	$i= $q->Pixmap("beopardy",-file => "img/beopardy.xpm");
+	if(defined($i)){
+		$q->Label(-image=>"beopardy")->pack(-side=>"top");
+	};
+
+	my $f = $q->Frame->pack(-fill=>'both',-expand=>1);
+	my $row=0;
+	foreach (1..$#players) {
+		my $e = $f->Label(qw/-relief sunken/);
+		$e->configure(-text => $points[$win[$_]]);
+		$e->configure(-font => $qfont) if ($_ == 1);
+
+		my $l = $f->Label(-text => "$players[$win[$_]]", 
+			-width		=> $namewidth,
+			-background	=> $colors[$win[$_]],
+			-foreground	=> "white",
+#			-anchor 	=> 'e', 
+			-justify => 'center');
+		$l->configure(-font => $qfont) if ($_ == 1);
+
+		Tk::grid( $l, -row => $row, -column => 0, -sticky => 'e');
+		Tk::grid( $e, -row => $row++, -column => 1,-sticky => 'ew');
+		$f->gridRowconfigure(1,-weight => 1);  
+	}
+	$dlgbtn=$q->Button(
+			-text	=> "bye",
+#			-font	=> $qfont,
+#			-width	=> 30,
+#			-height	=> 2,
+			-command	=> sub {&snd_stop;&ser_reset if($tty);$button[0][1]->focus; $button[0][1]->focusForce if ($force);$dlg->destroy; },
+	)->pack(
+			-fill	=>'x',
+			-expand	=>1,
+	);
+
+	$dlg->idletasks;
+	$dlg->geometry(sprintf "+%d+%d",($dlg->screenwidth-$dlg->width)/2,($dlg->screenheight-$dlg->height)/2);
+
+	$dlg->raise;
+	$dlg->grab;
+	$dlg->focusForce;
+	$tl->lower($dlg);
+};

--- a/beopardy
+++ b/beopardy
@@ -15,6 +15,7 @@ use Tk::Dialog;
 use Socket;
 use FileHandle;
 use Getopt::Std;
+use IO::Handle;
 
 # Global options. Set via getopt.
 my $debug=0;
@@ -38,6 +39,7 @@ my %ln = (
 		"ist etwas unruhig"	=> "seems a bit nervous",
 		"Knopf loesen"		=> "release your button",
 		"nochmal"			=> "try again",
+		"Zuhören..."		=> "listen...",
 		);
 
 sub _ {
@@ -164,7 +166,7 @@ if($soundd){
 		my $paddr   = sockaddr_in($port, $iaddr);
 		$proto   = getprotobyname('tcp');
 		connect(Soundd, $paddr)							|| die "connect: $!";
-		autoflush Soundd
+		autoflush Soundd;
 };
 &snd_stop(0); # Just to make sure, and to install snd_eat.
 
@@ -315,7 +317,7 @@ for my $cat (0..$#Cat){
 
 	for my $q (1..$q) {
 		$mframe[$cat][$q] = $frame[$cat]->Frame(
-				height => 1
+#				height => 1
 				)-> pack( -fill => 'both', -expand => 1);
 		$mframe[$cat][$q]->packPropagate(0);
 		$button[$cat][$q] = $mframe[$cat][$q]->Button(
@@ -533,7 +535,7 @@ sub ser_SelectPly {
 	my ($crap)=@_;
 
 	my $key=<Client>;
-	print "SER<: <$key>\n";
+	print "SER<: <$key>\n" if($debug);
 	$key=~s/\r?\n$//;
 	$key=$key+0;
 	if($key == 0){
@@ -621,7 +623,7 @@ sub selectQuest{
 		};
 		if($txt=~s/^\[(\w+):.*?\]\s*//){
 			if(!$txt){
-				$txt="Err. This should be of type $1";
+				$txt=_("Zuhören...");
 			};
 		};
 		$question = $tl->Label(
@@ -650,9 +652,10 @@ sub ser_answerQuest {
 	my ($crap,$c,$f)=@_;
 
 	my $key=<Client>;
-	print "SER<: <$key>\n";
+	print "SER<: <$key>\n" if($debug);
 
 #	&snd_play("think",1);
+	&snd_stop if($snd_save);
 
 	$key=~s/\r?\n$//;
 
@@ -686,7 +689,7 @@ sub ser_answerQuest {
 			-command	=> sub{
 							$ich->destroy;
 							&answerQuest($crap,$c,$f,-$key);
-#							&snd_resume;
+							&snd_resume;
 							$crap->focusForce if ($force);
 							&ser_en($crap,$c,$f)},
 	)->pack(-side	=>'left');
@@ -695,7 +698,7 @@ sub ser_answerQuest {
 			-command	=> sub{$ich->destroy;
 							  &ser_reset;
 #							  &snd_stop;
-#							  &snd_resume;
+							  &snd_resume;
 							  $crap->focusForce if ($force);
 							  &ser_en($crap,$c,$f)},
 	)->pack;
@@ -734,6 +737,7 @@ sub snd_play{
 	return if (!$soundd);
 	my($sound,$what)=(shift,shift);
 	print Soundd "P $sound\r\n";
+	Soundd->flush();
 	if($what){
 		$tl->fileevent(\*Soundd,'readable',[\&snd_color]); # DWIM!
 	}else{
@@ -743,11 +747,13 @@ sub snd_play{
 sub snd_stop{
 	return if (!$soundd);
 	print Soundd "Stop\r\n";
+	Soundd->flush();
 	$tl->fileevent(\*Soundd,'readable',[\&snd_eat]);
 };
 sub snd_zap{
 	return if (!$soundd);
 	print Soundd "Z\r\n";
+	Soundd->flush();
 	$tl->fileevent(\*Soundd,'readable',[\&snd_eat]);
 };
 
@@ -755,6 +761,7 @@ sub snd_resume{
 	return if (!$soundd);
 	if($snd_save){
 		print Soundd "P $snd_save\r\n";
+		Soundd->flush();
 	};
 	$tl->fileevent(\*Soundd,'readable',[\&snd_eat]);
 };
@@ -819,7 +826,7 @@ sub updPlayfield {
 			-height				=> 0,
 			-width				=> 0,
 			-background			=> $col,
-			-font				=> $qfont,
+			-font				=> "fixed",
 	);
 #	$button[$c][$f]->GeometryRequest(40,$oheight/2);
     print "Pts:",(map {sprintf "%s:%d/",$players[$_],$points[$_]} (1..$#points)),"\n";
@@ -847,9 +854,10 @@ sub ser_reset{
 	do {
 		&ser_dis;
 		print Client "R\r\n";
-	print "SER>: R\n";
+		Client->flush();
+	print "SER>: R\n" if($debug);
 		$ok=<Client>;
-	print "SER<: <$ok>\n";
+	print "SER<: <$ok>\n" if($debug);
 		$ok=~s/\r?\n//;
 		if ($ok ne "A"){
 			if ($ok =~ /(\d)/) {
@@ -901,7 +909,7 @@ sub ser_fatal{
 sub ser_eat {
 	my $ref=shift;
 	my $foo=scalar(<Client>);
-	print "SER<: <$foo>\n";
+	print "SER<: <$foo>\n" if($debug);
 	print "got: ",$foo;
 	$foo=~s/\r?\n//;
 	if($foo =~ /^\d+$/){


### PR DESCRIPTION
Schliesst das Fragefenster, nachdem alle Spieler falsch antworteten.
## Pro

Das ist nützlich, um in diesem Spezialfall den Spielverlauf zu beschleunigen (kein manuelles Drücken der '0' erforderlich).
## Contra

Bei der Hacker Jeopardy des CCC wird in solchen Situationen allerdings das Publikum befragt, wobei die Frage vom 'Boardmaster' noch eine Weile offen gehalten wird. Damit wird bei schwierigen Fragen die Stimmung im Saal gehoben.
